### PR TITLE
feat: ログイン画面の実装 (#4)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from "react";
+
+import { LoginForm } from "@/components/auth/login-form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const metadata = {
+  title: "ログイン | 営業日報システム",
+  description: "営業日報システムにログインしてください",
+};
+
+function LoginFormWrapper() {
+  return <LoginForm />;
+}
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/50 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">営業日報システム</CardTitle>
+          <CardDescription>
+            アカウント情報を入力してログインしてください
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Suspense fallback={<div className="text-center">読み込み中...</div>}>
+            <LoginFormWrapper />
+          </Suspense>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { login } from "@/lib/auth-actions";
+
+const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "メールアドレスを入力してください")
+    .email("有効なメールアドレスを入力してください"),
+  password: z.string().min(1, "パスワードを入力してください"),
+  remember: z.boolean(),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+export function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+      remember: false,
+    },
+  });
+
+  async function onSubmit(data: LoginFormValues) {
+    setError(null);
+
+    startTransition(async () => {
+      const result = await login(data.email, data.password, callbackUrl);
+
+      if (result?.error) {
+        setError(result.error);
+        return;
+      }
+
+      // If no error and no redirect happened (shouldn't happen normally),
+      // manually redirect
+      router.push(callbackUrl);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メールアドレス</FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  placeholder="example@example.com"
+                  autoComplete="email"
+                  disabled={isPending}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>パスワード</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="パスワードを入力"
+                  autoComplete="current-password"
+                  disabled={isPending}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="remember"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center space-x-2 space-y-0">
+              <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormLabel className="text-sm font-normal cursor-pointer">
+                ログイン状態を保持する
+              </FormLabel>
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full" disabled={isPending}>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          ログイン
+        </Button>
+      </form>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary
- ログインページ (`/login`) を実装
- メールアドレス・パスワードのZodバリデーション
- react-hook-formによるフォーム状態管理
- ログイン状態保持チェックボックス
- ローディング状態とエラーメッセージ表示
- NextAuth.jsとの連携

## 関連Issue
Closes #4

## 実装内容
### 新規ファイル
- `src/app/login/page.tsx` - ログインページ
- `src/components/auth/login-form.tsx` - ログインフォームコンポーネント

### 機能
- メールアドレス形式バリデーション
- パスワード必須チェック
- ログインエラー時のメッセージ表示
- ログイン中のローディング表示
- 認証成功後のリダイレクト

## Test plan
- [ ] `/login` にアクセスしてログイン画面が表示されることを確認
- [ ] 空のフォームで送信するとバリデーションエラーが表示される
- [ ] 不正なメールアドレス形式でエラーが表示される
- [ ] 正しい認証情報でログインできる
- [ ] 認証エラー時にエラーメッセージが表示される
- [ ] ログイン中はボタンがdisabledになりローディング表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)