### PR TITLE
feat: API共通基盤の実装（エラーハンドリング・バリデーション）

### DIFF
--- a/src/lib/api/errors.test.ts
+++ b/src/lib/api/errors.test.ts
@@ -1,0 +1,270 @@
+/**
+ * エラー定義のテスト
+ */
+
+import {
+  ApiError,
+  createApiError,
+  ErrorCode,
+  ErrorCodeDefaultMessage,
+  ErrorCodeToHttpStatus,
+} from "./errors";
+
+import type { ErrorCodeType } from "./errors";
+
+describe("ErrorCode", () => {
+  it("認証関連エラーコードが定義されている", () => {
+    expect(ErrorCode.AUTH_INVALID_CREDENTIALS).toBe("AUTH_INVALID_CREDENTIALS");
+    expect(ErrorCode.AUTH_TOKEN_EXPIRED).toBe("AUTH_TOKEN_EXPIRED");
+    expect(ErrorCode.AUTH_UNAUTHORIZED).toBe("AUTH_UNAUTHORIZED");
+  });
+
+  it("権限関連エラーコードが定義されている", () => {
+    expect(ErrorCode.FORBIDDEN_ACCESS).toBe("FORBIDDEN_ACCESS");
+    expect(ErrorCode.FORBIDDEN_EDIT).toBe("FORBIDDEN_EDIT");
+    expect(ErrorCode.FORBIDDEN_DELETE).toBe("FORBIDDEN_DELETE");
+  });
+
+  it("バリデーション関連エラーコードが定義されている", () => {
+    expect(ErrorCode.VALIDATION_ERROR).toBe("VALIDATION_ERROR");
+    expect(ErrorCode.DUPLICATE_ENTRY).toBe("DUPLICATE_ENTRY");
+  });
+
+  it("リソース関連エラーコードが定義されている", () => {
+    expect(ErrorCode.RESOURCE_NOT_FOUND).toBe("RESOURCE_NOT_FOUND");
+    expect(ErrorCode.RESOURCE_IN_USE).toBe("RESOURCE_IN_USE");
+  });
+
+  it("内部エラーコードが定義されている", () => {
+    expect(ErrorCode.INTERNAL_ERROR).toBe("INTERNAL_ERROR");
+    expect(ErrorCode.SERVICE_UNAVAILABLE).toBe("SERVICE_UNAVAILABLE");
+  });
+});
+
+describe("ErrorCodeToHttpStatus", () => {
+  it("認証エラーは401を返す", () => {
+    expect(ErrorCodeToHttpStatus[ErrorCode.AUTH_INVALID_CREDENTIALS]).toBe(401);
+    expect(ErrorCodeToHttpStatus[ErrorCode.AUTH_TOKEN_EXPIRED]).toBe(401);
+    expect(ErrorCodeToHttpStatus[ErrorCode.AUTH_UNAUTHORIZED]).toBe(401);
+  });
+
+  it("権限エラーは403を返す", () => {
+    expect(ErrorCodeToHttpStatus[ErrorCode.FORBIDDEN_ACCESS]).toBe(403);
+    expect(ErrorCodeToHttpStatus[ErrorCode.FORBIDDEN_EDIT]).toBe(403);
+    expect(ErrorCodeToHttpStatus[ErrorCode.FORBIDDEN_DELETE]).toBe(403);
+  });
+
+  it("バリデーションエラーは422、重複エラーは400を返す", () => {
+    expect(ErrorCodeToHttpStatus[ErrorCode.VALIDATION_ERROR]).toBe(422);
+    expect(ErrorCodeToHttpStatus[ErrorCode.DUPLICATE_ENTRY]).toBe(400);
+  });
+
+  it("リソースエラーは404または409を返す", () => {
+    expect(ErrorCodeToHttpStatus[ErrorCode.RESOURCE_NOT_FOUND]).toBe(404);
+    expect(ErrorCodeToHttpStatus[ErrorCode.RESOURCE_IN_USE]).toBe(409);
+  });
+
+  it("内部エラーは500または503を返す", () => {
+    expect(ErrorCodeToHttpStatus[ErrorCode.INTERNAL_ERROR]).toBe(500);
+    expect(ErrorCodeToHttpStatus[ErrorCode.SERVICE_UNAVAILABLE]).toBe(503);
+  });
+
+  it("すべてのエラーコードに対してHTTPステータスが定義されている", () => {
+    const allErrorCodes = Object.values(ErrorCode) as ErrorCodeType[];
+    allErrorCodes.forEach((code) => {
+      expect(ErrorCodeToHttpStatus[code]).toBeDefined();
+      expect(typeof ErrorCodeToHttpStatus[code]).toBe("number");
+    });
+  });
+});
+
+describe("ErrorCodeDefaultMessage", () => {
+  it("すべてのエラーコードに対してデフォルトメッセージが定義されている", () => {
+    const allErrorCodes = Object.values(ErrorCode) as ErrorCodeType[];
+    allErrorCodes.forEach((code) => {
+      expect(ErrorCodeDefaultMessage[code]).toBeDefined();
+      expect(typeof ErrorCodeDefaultMessage[code]).toBe("string");
+      expect(ErrorCodeDefaultMessage[code].length).toBeGreaterThan(0);
+    });
+  });
+
+  it("認証エラーのメッセージが適切である", () => {
+    expect(ErrorCodeDefaultMessage[ErrorCode.AUTH_INVALID_CREDENTIALS]).toBe(
+      "認証情報が無効です"
+    );
+    expect(ErrorCodeDefaultMessage[ErrorCode.AUTH_TOKEN_EXPIRED]).toBe(
+      "認証トークンの有効期限が切れています"
+    );
+    expect(ErrorCodeDefaultMessage[ErrorCode.AUTH_UNAUTHORIZED]).toBe(
+      "認証が必要です"
+    );
+  });
+});
+
+describe("ApiError", () => {
+  it("エラーコードとデフォルトメッセージでインスタンスを作成できる", () => {
+    const error = new ApiError(ErrorCode.RESOURCE_NOT_FOUND);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe(ErrorCode.RESOURCE_NOT_FOUND);
+    expect(error.message).toBe(
+      ErrorCodeDefaultMessage[ErrorCode.RESOURCE_NOT_FOUND]
+    );
+    expect(error.statusCode).toBe(404);
+    expect(error.details).toBeUndefined();
+  });
+
+  it("カスタムメッセージを指定できる", () => {
+    const customMessage = "ユーザーが見つかりません";
+    const error = new ApiError(ErrorCode.RESOURCE_NOT_FOUND, customMessage);
+
+    expect(error.message).toBe(customMessage);
+    expect(error.code).toBe(ErrorCode.RESOURCE_NOT_FOUND);
+  });
+
+  it("詳細情報を指定できる", () => {
+    const details = [
+      { field: "email", message: "メールアドレスが無効です" },
+      { field: "password", message: "パスワードが短すぎます" },
+    ];
+    const error = new ApiError(
+      ErrorCode.VALIDATION_ERROR,
+      "バリデーションエラー",
+      details
+    );
+
+    expect(error.details).toEqual(details);
+  });
+
+  it("toJSONメソッドで正しくシリアライズできる", () => {
+    const details = [{ field: "name", message: "名前は必須です" }];
+    const error = new ApiError(
+      ErrorCode.VALIDATION_ERROR,
+      "バリデーションエラー",
+      details
+    );
+
+    const json = error.toJSON();
+
+    expect(json).toEqual({
+      code: ErrorCode.VALIDATION_ERROR,
+      message: "バリデーションエラー",
+      details,
+    });
+  });
+
+  it("詳細がない場合toJSONにはdetailsがundefinedで含まれる", () => {
+    const error = new ApiError(ErrorCode.INTERNAL_ERROR);
+    const json = error.toJSON();
+
+    expect(json).toEqual({
+      code: ErrorCode.INTERNAL_ERROR,
+      message: ErrorCodeDefaultMessage[ErrorCode.INTERNAL_ERROR],
+      details: undefined,
+    });
+  });
+
+  it("Errorのプロトタイプチェーンが正しく設定されている", () => {
+    const error = new ApiError(ErrorCode.INTERNAL_ERROR);
+
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof ApiError).toBe(true);
+    expect(error.name).toBe("ApiError");
+  });
+});
+
+describe("createApiError", () => {
+  it("invalidCredentialsでAUTH_INVALID_CREDENTIALSエラーを作成できる", () => {
+    const error = createApiError.invalidCredentials();
+
+    expect(error.code).toBe(ErrorCode.AUTH_INVALID_CREDENTIALS);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it("invalidCredentialsでカスタムメッセージを指定できる", () => {
+    const customMessage = "パスワードが間違っています";
+    const error = createApiError.invalidCredentials(customMessage);
+
+    expect(error.message).toBe(customMessage);
+  });
+
+  it("tokenExpiredでAUTH_TOKEN_EXPIREDエラーを作成できる", () => {
+    const error = createApiError.tokenExpired();
+
+    expect(error.code).toBe(ErrorCode.AUTH_TOKEN_EXPIRED);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it("unauthorizedでAUTH_UNAUTHORIZEDエラーを作成できる", () => {
+    const error = createApiError.unauthorized();
+
+    expect(error.code).toBe(ErrorCode.AUTH_UNAUTHORIZED);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it("forbiddenAccessでFORBIDDEN_ACCESSエラーを作成できる", () => {
+    const error = createApiError.forbiddenAccess();
+
+    expect(error.code).toBe(ErrorCode.FORBIDDEN_ACCESS);
+    expect(error.statusCode).toBe(403);
+  });
+
+  it("forbiddenEditでFORBIDDEN_EDITエラーを作成できる", () => {
+    const error = createApiError.forbiddenEdit();
+
+    expect(error.code).toBe(ErrorCode.FORBIDDEN_EDIT);
+    expect(error.statusCode).toBe(403);
+  });
+
+  it("forbiddenDeleteでFORBIDDEN_DELETEエラーを作成できる", () => {
+    const error = createApiError.forbiddenDelete();
+
+    expect(error.code).toBe(ErrorCode.FORBIDDEN_DELETE);
+    expect(error.statusCode).toBe(403);
+  });
+
+  it("validationErrorでVALIDATION_ERRORエラーを作成できる", () => {
+    const details = [{ field: "email", message: "無効なメールアドレス" }];
+    const error = createApiError.validationError("入力エラー", details);
+
+    expect(error.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(error.statusCode).toBe(422);
+    expect(error.details).toEqual(details);
+  });
+
+  it("duplicateEntryでDUPLICATE_ENTRYエラーを作成できる", () => {
+    const error = createApiError.duplicateEntry();
+
+    expect(error.code).toBe(ErrorCode.DUPLICATE_ENTRY);
+    expect(error.statusCode).toBe(400);
+  });
+
+  it("notFoundでRESOURCE_NOT_FOUNDエラーを作成できる", () => {
+    const error = createApiError.notFound();
+
+    expect(error.code).toBe(ErrorCode.RESOURCE_NOT_FOUND);
+    expect(error.statusCode).toBe(404);
+  });
+
+  it("resourceInUseでRESOURCE_IN_USEエラーを作成できる", () => {
+    const error = createApiError.resourceInUse();
+
+    expect(error.code).toBe(ErrorCode.RESOURCE_IN_USE);
+    expect(error.statusCode).toBe(409);
+  });
+
+  it("internalErrorでINTERNAL_ERRORエラーを作成できる", () => {
+    const error = createApiError.internalError();
+
+    expect(error.code).toBe(ErrorCode.INTERNAL_ERROR);
+    expect(error.statusCode).toBe(500);
+  });
+
+  it("serviceUnavailableでSERVICE_UNAVAILABLEエラーを作成できる", () => {
+    const error = createApiError.serviceUnavailable();
+
+    expect(error.code).toBe(ErrorCode.SERVICE_UNAVAILABLE);
+    expect(error.statusCode).toBe(503);
+  });
+});

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,179 @@
+/**
+ * API共通エラーコード定義
+ *
+ * エラーコードは以下のカテゴリに分類されます:
+ * - AUTH_*: 認証関連エラー
+ * - FORBIDDEN_*: 権限関連エラー
+ * - VALIDATION_*: バリデーション関連エラー
+ * - RESOURCE_*: リソース関連エラー
+ * - INTERNAL_*: 内部エラー
+ */
+
+/**
+ * エラーコードの定義
+ */
+export const ErrorCode = {
+  // 認証関連エラー (401)
+  AUTH_INVALID_CREDENTIALS: "AUTH_INVALID_CREDENTIALS",
+  AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
+  AUTH_UNAUTHORIZED: "AUTH_UNAUTHORIZED",
+
+  // 権限関連エラー (403)
+  FORBIDDEN_ACCESS: "FORBIDDEN_ACCESS",
+  FORBIDDEN_EDIT: "FORBIDDEN_EDIT",
+  FORBIDDEN_DELETE: "FORBIDDEN_DELETE",
+
+  // バリデーション関連エラー (400, 422)
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  DUPLICATE_ENTRY: "DUPLICATE_ENTRY",
+
+  // リソース関連エラー (404, 409)
+  RESOURCE_NOT_FOUND: "RESOURCE_NOT_FOUND",
+  RESOURCE_IN_USE: "RESOURCE_IN_USE",
+
+  // 内部エラー (500, 503)
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+  SERVICE_UNAVAILABLE: "SERVICE_UNAVAILABLE",
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * エラーコードとHTTPステータスコードのマッピング
+ */
+export const ErrorCodeToHttpStatus: Record<ErrorCodeType, number> = {
+  // 認証関連エラー
+  [ErrorCode.AUTH_INVALID_CREDENTIALS]: 401,
+  [ErrorCode.AUTH_TOKEN_EXPIRED]: 401,
+  [ErrorCode.AUTH_UNAUTHORIZED]: 401,
+
+  // 権限関連エラー
+  [ErrorCode.FORBIDDEN_ACCESS]: 403,
+  [ErrorCode.FORBIDDEN_EDIT]: 403,
+  [ErrorCode.FORBIDDEN_DELETE]: 403,
+
+  // バリデーション関連エラー
+  [ErrorCode.VALIDATION_ERROR]: 422,
+  [ErrorCode.DUPLICATE_ENTRY]: 400,
+
+  // リソース関連エラー
+  [ErrorCode.RESOURCE_NOT_FOUND]: 404,
+  [ErrorCode.RESOURCE_IN_USE]: 409,
+
+  // 内部エラー
+  [ErrorCode.INTERNAL_ERROR]: 500,
+  [ErrorCode.SERVICE_UNAVAILABLE]: 503,
+};
+
+/**
+ * エラーコードのデフォルトメッセージ
+ */
+export const ErrorCodeDefaultMessage: Record<ErrorCodeType, string> = {
+  // 認証関連エラー
+  [ErrorCode.AUTH_INVALID_CREDENTIALS]: "認証情報が無効です",
+  [ErrorCode.AUTH_TOKEN_EXPIRED]: "認証トークンの有効期限が切れています",
+  [ErrorCode.AUTH_UNAUTHORIZED]: "認証が必要です",
+
+  // 権限関連エラー
+  [ErrorCode.FORBIDDEN_ACCESS]: "このリソースへのアクセス権限がありません",
+  [ErrorCode.FORBIDDEN_EDIT]: "このリソースの編集権限がありません",
+  [ErrorCode.FORBIDDEN_DELETE]: "このリソースの削除権限がありません",
+
+  // バリデーション関連エラー
+  [ErrorCode.VALIDATION_ERROR]: "入力内容に誤りがあります",
+  [ErrorCode.DUPLICATE_ENTRY]: "既に登録されているデータです",
+
+  // リソース関連エラー
+  [ErrorCode.RESOURCE_NOT_FOUND]: "指定されたリソースが見つかりません",
+  [ErrorCode.RESOURCE_IN_USE]: "このリソースは使用中のため操作できません",
+
+  // 内部エラー
+  [ErrorCode.INTERNAL_ERROR]: "サーバー内部エラーが発生しました",
+  [ErrorCode.SERVICE_UNAVAILABLE]: "サービスが一時的に利用できません",
+};
+
+/**
+ * APIエラークラス
+ *
+ * API内で発生するエラーを統一的に扱うためのカスタムエラークラス
+ */
+export class ApiError extends Error {
+  public readonly code: ErrorCodeType;
+  public readonly statusCode: number;
+  public readonly details: unknown[] | undefined;
+
+  constructor(code: ErrorCodeType, message?: string, details?: unknown[]) {
+    super(message ?? ErrorCodeDefaultMessage[code]);
+    this.name = "ApiError";
+    this.code = code;
+    this.statusCode = ErrorCodeToHttpStatus[code];
+    this.details = details ?? undefined;
+
+    // Error クラスを継承する際の prototype chain を正しく設定
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+
+  /**
+   * JSONシリアライズ用のオブジェクトを生成
+   */
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+      details: this.details,
+    };
+  }
+}
+
+/**
+ * 便利なエラー生成関数
+ */
+export const createApiError = {
+  /** 認証エラー: 無効な認証情報 */
+  invalidCredentials: (message?: string) =>
+    new ApiError(ErrorCode.AUTH_INVALID_CREDENTIALS, message),
+
+  /** 認証エラー: トークン期限切れ */
+  tokenExpired: (message?: string) =>
+    new ApiError(ErrorCode.AUTH_TOKEN_EXPIRED, message),
+
+  /** 認証エラー: 未認証 */
+  unauthorized: (message?: string) =>
+    new ApiError(ErrorCode.AUTH_UNAUTHORIZED, message),
+
+  /** 権限エラー: アクセス禁止 */
+  forbiddenAccess: (message?: string) =>
+    new ApiError(ErrorCode.FORBIDDEN_ACCESS, message),
+
+  /** 権限エラー: 編集禁止 */
+  forbiddenEdit: (message?: string) =>
+    new ApiError(ErrorCode.FORBIDDEN_EDIT, message),
+
+  /** 権限エラー: 削除禁止 */
+  forbiddenDelete: (message?: string) =>
+    new ApiError(ErrorCode.FORBIDDEN_DELETE, message),
+
+  /** バリデーションエラー */
+  validationError: (message?: string, details?: unknown[]) =>
+    new ApiError(ErrorCode.VALIDATION_ERROR, message, details),
+
+  /** 重複エラー */
+  duplicateEntry: (message?: string) =>
+    new ApiError(ErrorCode.DUPLICATE_ENTRY, message),
+
+  /** リソース未検出エラー */
+  notFound: (message?: string) =>
+    new ApiError(ErrorCode.RESOURCE_NOT_FOUND, message),
+
+  /** リソース使用中エラー */
+  resourceInUse: (message?: string) =>
+    new ApiError(ErrorCode.RESOURCE_IN_USE, message),
+
+  /** 内部エラー */
+  internalError: (message?: string) =>
+    new ApiError(ErrorCode.INTERNAL_ERROR, message),
+
+  /** サービス利用不可エラー */
+  serviceUnavailable: (message?: string) =>
+    new ApiError(ErrorCode.SERVICE_UNAVAILABLE, message),
+};

--- a/src/lib/api/handler.test.ts
+++ b/src/lib/api/handler.test.ts
@@ -1,0 +1,388 @@
+/**
+ * APIルートハンドラーラッパーのテスト
+ */
+
+import { z } from "zod";
+
+import { ApiError, ErrorCode } from "./errors";
+import { createHandlers, withAuthHandler, withHandler } from "./handler";
+import { successResponse } from "./response";
+
+import type { RouteContext } from "./handler";
+import type { NextRequest } from "next/server";
+
+// モック用のNextRequestを作成
+function createMockRequest(
+  url = "http://localhost/api/test",
+  options: RequestInit = {}
+): NextRequest {
+  return new Request(url, options) as NextRequest;
+}
+
+// モック用のRouteContextを作成
+function createMockContext<T = Record<string, string>>(
+  params: T = {} as T
+): RouteContext<T> {
+  return {
+    params: Promise.resolve(params),
+  };
+}
+
+describe("withHandler", () => {
+  it("正常なレスポンスをそのまま返す", async () => {
+    const handler = withHandler(async () => {
+      return successResponse({ message: "success" });
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { message: "success" },
+    });
+  });
+
+  it("ApiErrorをキャッチしてエラーレスポンスに変換する", async () => {
+    const handler = withHandler(async () => {
+      throw new ApiError(
+        ErrorCode.RESOURCE_NOT_FOUND,
+        "ユーザーが見つかりません"
+      );
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "RESOURCE_NOT_FOUND",
+        message: "ユーザーが見つかりません",
+      },
+    });
+  });
+
+  it("ZodErrorをキャッチしてバリデーションエラーレスポンスに変換する", async () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    const handler = withHandler(async () => {
+      schema.parse({ name: 123 });
+      return successResponse({});
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(422);
+
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details).toBeDefined();
+    expect(body.error.details.length).toBeGreaterThan(0);
+  });
+
+  it("JSONパースエラーをキャッチしてバリデーションエラーに変換する", async () => {
+    const handler = withHandler(async () => {
+      throw new SyntaxError("Unexpected token in JSON");
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(422);
+
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.message).toBe("リクエスト形式が不正です");
+  });
+
+  it("未知のエラーは内部エラーレスポンスに変換する", async () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    // production モードでテスト
+    vi.stubEnv("NODE_ENV", "production");
+
+    const handler = withHandler(
+      async () => {
+        throw new Error("予期しないエラー");
+      },
+      { logErrors: false }
+    );
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(500);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "サーバー内部エラーが発生しました",
+      },
+    });
+
+    vi.stubEnv("NODE_ENV", originalEnv);
+  });
+
+  it("開発環境では未知のエラーの詳細メッセージを表示する", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    const handler = withHandler(
+      async () => {
+        throw new Error("詳細なエラーメッセージ");
+      },
+      { logErrors: false }
+    );
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(500);
+
+    const body = await response.json();
+    expect(body.error.message).toBe("詳細なエラーメッセージ");
+
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  it("リクエストとコンテキストをハンドラーに渡す", async () => {
+    let receivedRequest: NextRequest | undefined;
+    let receivedContext: RouteContext | undefined;
+
+    const handler = withHandler(async (req, ctx) => {
+      receivedRequest = req;
+      receivedContext = ctx;
+      return successResponse({});
+    });
+
+    const mockRequest = createMockRequest("http://localhost/api/test?id=123");
+    const mockContext = createMockContext({ userId: "abc" });
+
+    await handler(mockRequest, mockContext);
+
+    expect(receivedRequest).toBe(mockRequest);
+    expect(receivedContext).toBe(mockContext);
+  });
+
+  it("パスパラメータを正しく受け取る", async () => {
+    const handler = withHandler<{ id: string }>(async (_req, ctx) => {
+      const params = await ctx.params;
+      return successResponse({ id: params.id });
+    });
+
+    const response = await handler(
+      createMockRequest(),
+      createMockContext({ id: "123" })
+    );
+
+    const body = await response.json();
+    expect(body.data.id).toBe("123");
+  });
+
+  it("詳細情報付きApiErrorを正しく処理する", async () => {
+    const details = [
+      { field: "email", message: "メールアドレスが無効です" },
+      { field: "password", message: "パスワードが短すぎます" },
+    ];
+
+    const handler = withHandler(async () => {
+      throw new ApiError(
+        ErrorCode.VALIDATION_ERROR,
+        "入力内容に誤りがあります",
+        details
+      );
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    const body = await response.json();
+    expect(body.error.details).toEqual(details);
+  });
+});
+
+describe("withAuthHandler", () => {
+  it("基本的なラッピングが機能する", async () => {
+    const handler = withAuthHandler(async () => {
+      return successResponse({ authenticated: true });
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.authenticated).toBe(true);
+  });
+
+  it("エラーハンドリングが機能する", async () => {
+    const handler = withAuthHandler(async () => {
+      throw new ApiError(ErrorCode.AUTH_UNAUTHORIZED);
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(401);
+
+    const body = await response.json();
+    expect(body.error.code).toBe("AUTH_UNAUTHORIZED");
+  });
+});
+
+describe("createHandlers", () => {
+  it("GETハンドラーを作成できる", async () => {
+    const handlers = createHandlers({
+      GET: async () => successResponse({ method: "GET" }),
+    });
+
+    expect(handlers.GET).toBeDefined();
+    expect(handlers.POST).toBeUndefined();
+
+    const response = await handlers.GET!(
+      createMockRequest(),
+      createMockContext()
+    );
+
+    const body = await response.json();
+    expect(body.data.method).toBe("GET");
+  });
+
+  it("POSTハンドラーを作成できる", async () => {
+    const handlers = createHandlers({
+      POST: async () => successResponse({ method: "POST" }),
+    });
+
+    expect(handlers.POST).toBeDefined();
+
+    const response = await handlers.POST!(
+      createMockRequest(),
+      createMockContext()
+    );
+
+    const body = await response.json();
+    expect(body.data.method).toBe("POST");
+  });
+
+  it("複数のハンドラーを作成できる", async () => {
+    const handlers = createHandlers({
+      GET: async () => successResponse({ method: "GET" }),
+      POST: async () => successResponse({ method: "POST" }),
+      PUT: async () => successResponse({ method: "PUT" }),
+      PATCH: async () => successResponse({ method: "PATCH" }),
+      DELETE: async () => successResponse({ method: "DELETE" }),
+    });
+
+    expect(handlers.GET).toBeDefined();
+    expect(handlers.POST).toBeDefined();
+    expect(handlers.PUT).toBeDefined();
+    expect(handlers.PATCH).toBeDefined();
+    expect(handlers.DELETE).toBeDefined();
+  });
+
+  it("すべてのハンドラーがエラーハンドリングを持つ", async () => {
+    const handlers = createHandlers({
+      GET: async () => {
+        throw new ApiError(ErrorCode.RESOURCE_NOT_FOUND);
+      },
+      POST: async () => {
+        throw new ApiError(ErrorCode.VALIDATION_ERROR);
+      },
+    });
+
+    const getResponse = await handlers.GET!(
+      createMockRequest(),
+      createMockContext()
+    );
+    expect(getResponse.status).toBe(404);
+
+    const postResponse = await handlers.POST!(
+      createMockRequest(),
+      createMockContext()
+    );
+    expect(postResponse.status).toBe(422);
+  });
+
+  it("パスパラメータの型を正しく扱える", async () => {
+    const handlers = createHandlers<{ userId: string; postId: string }>({
+      GET: async (_req, ctx) => {
+        const params = await ctx.params;
+        return successResponse({
+          userId: params.userId,
+          postId: params.postId,
+        });
+      },
+    });
+
+    const response = await handlers.GET!(
+      createMockRequest(),
+      createMockContext({ userId: "user-1", postId: "post-1" })
+    );
+
+    const body = await response.json();
+    expect(body.data).toEqual({
+      userId: "user-1",
+      postId: "post-1",
+    });
+  });
+
+  it("オプションを渡せる", async () => {
+    // logErrors オプションが渡されることを確認（コンソール出力なし）
+    const handlers = createHandlers(
+      {
+        GET: async () => {
+          throw new Error("テストエラー");
+        },
+      },
+      { logErrors: false }
+    );
+
+    const response = await handlers.GET!(
+      createMockRequest(),
+      createMockContext()
+    );
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("エラーハンドリングの統合テスト", () => {
+  it("ネストしたエラーも正しく処理される", async () => {
+    const handler = withHandler(async () => {
+      async function innerFunction() {
+        throw new ApiError(ErrorCode.FORBIDDEN_ACCESS, "アクセス禁止");
+      }
+
+      await innerFunction();
+      return successResponse({});
+    });
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(403);
+
+    const body = await response.json();
+    expect(body.error.code).toBe("FORBIDDEN_ACCESS");
+  });
+
+  it("非Errorオブジェクトのスローも処理される", async () => {
+    const handler = withHandler(
+      async () => {
+        throw "string error";
+      },
+      { logErrors: false }
+    );
+
+    const response = await handler(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(500);
+
+    const body = await response.json();
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -1,0 +1,234 @@
+/**
+ * APIルートハンドラーラッパー
+ *
+ * 統一されたエラーハンドリングと認証チェックを提供します
+ */
+
+import { ZodError } from "zod";
+
+import { ApiError } from "./errors";
+import {
+  apiErrorResponse,
+  internalErrorResponse,
+  validationErrorResponse,
+} from "./response";
+import { zodErrorToDetails } from "./validation";
+
+import type { ErrorDetail, ErrorResponse } from "./response";
+import type { NextRequest, NextResponse } from "next/server";
+
+/**
+ * ルートハンドラーのコンテキスト型
+ */
+export interface RouteContext<TParams = Record<string, string | string[]>> {
+  params: Promise<TParams>;
+}
+
+/**
+ * ルートハンドラーの基本型
+ */
+export type RouteHandler<TParams = Record<string, string | string[]>> = (
+  request: NextRequest,
+  context: RouteContext<TParams>
+) => Promise<NextResponse>;
+
+/**
+ * ハンドラーオプション
+ */
+export interface HandlerOptions {
+  /** エラーをコンソールに出力するかどうか (デフォルト: true in development) */
+  logErrors?: boolean;
+}
+
+/**
+ * エラーをNextResponseに変換
+ *
+ * @param error 発生したエラー
+ * @param options ハンドラーオプション
+ * @returns NextResponse
+ */
+function handleError(
+  error: unknown,
+  options?: HandlerOptions
+): NextResponse<ErrorResponse> {
+  const shouldLog =
+    options?.logErrors ?? process.env.NODE_ENV === "development";
+
+  // ApiError の場合
+  if (error instanceof ApiError) {
+    if (shouldLog) {
+      console.error(
+        `[ApiError] ${error.code}: ${error.message}`,
+        error.details
+      );
+    }
+    return apiErrorResponse(error);
+  }
+
+  // ZodError の場合
+  if (error instanceof ZodError) {
+    const details = zodErrorToDetails(error);
+    if (shouldLog) {
+      console.error("[ZodError] Validation failed:", details);
+    }
+    return validationErrorResponse(details);
+  }
+
+  // SyntaxError (JSON パースエラー) の場合
+  if (error instanceof SyntaxError && error.message.includes("JSON")) {
+    if (shouldLog) {
+      console.error("[SyntaxError] JSON parse error:", error.message);
+    }
+    const details: ErrorDetail[] = [
+      { message: "リクエストボディのJSONパースに失敗しました" },
+    ];
+    return validationErrorResponse(details, "リクエスト形式が不正です");
+  }
+
+  // その他のエラー
+  if (shouldLog) {
+    console.error("[UnhandledError]", error);
+  }
+
+  // 本番環境では詳細なエラー情報を隠す
+  const message =
+    process.env.NODE_ENV === "development" && error instanceof Error
+      ? error.message
+      : "サーバー内部エラーが発生しました";
+
+  return internalErrorResponse(message);
+}
+
+/**
+ * APIルートハンドラーをラップしてエラーハンドリングを追加
+ *
+ * @param handler ルートハンドラー関数
+ * @param options ハンドラーオプション
+ * @returns ラップされたルートハンドラー
+ *
+ * @example
+ * ```typescript
+ * // app/api/users/route.ts
+ * import { withHandler } from '@/lib/api/handler';
+ * import { successResponse } from '@/lib/api/response';
+ *
+ * export const GET = withHandler(async (request) => {
+ *   const users = await getUsers();
+ *   return successResponse(users);
+ * });
+ * ```
+ */
+export function withHandler<TParams = Record<string, string | string[]>>(
+  handler: RouteHandler<TParams>,
+  options?: HandlerOptions
+): RouteHandler<TParams> {
+  return async (request: NextRequest, context: RouteContext<TParams>) => {
+    try {
+      return await handler(request, context);
+    } catch (error) {
+      return handleError(error, options);
+    }
+  };
+}
+
+/**
+ * 認証が必要なAPIルートハンドラーをラップ
+ *
+ * @param handler ルートハンドラー関数
+ * @param options ハンドラーオプション
+ * @returns ラップされたルートハンドラー
+ *
+ * @example
+ * ```typescript
+ * // app/api/protected/route.ts
+ * import { withAuthHandler } from '@/lib/api/handler';
+ * import { successResponse } from '@/lib/api/response';
+ *
+ * export const GET = withAuthHandler(async (request, context) => {
+ *   const { session } = context;
+ *   return successResponse({ userId: session.user.id });
+ * });
+ * ```
+ */
+export function withAuthHandler<TParams = Record<string, string | string[]>>(
+  handler: RouteHandler<TParams>,
+  options?: HandlerOptions
+): RouteHandler<TParams> {
+  return withHandler(async (request, context) => {
+    // 認証チェックは auth.ts の getServerSession を使用
+    // ここでは基本的なハンドラーラッピングのみ提供
+    // 実際の認証チェックは各ルートで行う
+    return handler(request, context);
+  }, options);
+}
+
+/**
+ * 複数のHTTPメソッドに対応するハンドラーを作成
+ *
+ * @param handlers メソッド別のハンドラー
+ * @param options ハンドラーオプション
+ * @returns メソッド別にエクスポートできるハンドラーオブジェクト
+ *
+ * @example
+ * ```typescript
+ * // app/api/users/route.ts
+ * import { createHandlers } from '@/lib/api/handler';
+ * import { successResponse, createdResponse } from '@/lib/api/response';
+ *
+ * const handlers = createHandlers({
+ *   GET: async (request) => {
+ *     const users = await getUsers();
+ *     return successResponse(users);
+ *   },
+ *   POST: async (request) => {
+ *     const body = await request.json();
+ *     const user = await createUser(body);
+ *     return createdResponse(user);
+ *   },
+ * });
+ *
+ * export const { GET, POST } = handlers;
+ * ```
+ */
+export function createHandlers<TParams = Record<string, string | string[]>>(
+  handlers: Partial<{
+    GET: RouteHandler<TParams>;
+    POST: RouteHandler<TParams>;
+    PUT: RouteHandler<TParams>;
+    PATCH: RouteHandler<TParams>;
+    DELETE: RouteHandler<TParams>;
+  }>,
+  options?: HandlerOptions
+): {
+  GET?: RouteHandler<TParams>;
+  POST?: RouteHandler<TParams>;
+  PUT?: RouteHandler<TParams>;
+  PATCH?: RouteHandler<TParams>;
+  DELETE?: RouteHandler<TParams>;
+} {
+  const result: Partial<{
+    GET: RouteHandler<TParams>;
+    POST: RouteHandler<TParams>;
+    PUT: RouteHandler<TParams>;
+    PATCH: RouteHandler<TParams>;
+    DELETE: RouteHandler<TParams>;
+  }> = {};
+
+  if (handlers.GET) {
+    result.GET = withHandler(handlers.GET, options);
+  }
+  if (handlers.POST) {
+    result.POST = withHandler(handlers.POST, options);
+  }
+  if (handlers.PUT) {
+    result.PUT = withHandler(handlers.PUT, options);
+  }
+  if (handlers.PATCH) {
+    result.PATCH = withHandler(handlers.PATCH, options);
+  }
+  if (handlers.DELETE) {
+    result.DELETE = withHandler(handlers.DELETE, options);
+  }
+
+  return result;
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,71 @@
+/**
+ * API共通基盤
+ *
+ * 統一されたAPIレスポンス形式、エラーハンドリング、バリデーション機能を提供します
+ */
+
+// エラー関連
+export {
+  ErrorCode,
+  ErrorCodeToHttpStatus,
+  ErrorCodeDefaultMessage,
+  ApiError,
+  createApiError,
+  type ErrorCodeType,
+} from "./errors";
+
+// レスポンス関連
+export {
+  successResponse,
+  createdResponse,
+  paginatedResponse,
+  errorResponse,
+  apiErrorResponse,
+  validationErrorResponse,
+  unauthorizedResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  internalErrorResponse,
+  HttpStatus,
+  type SuccessResponse,
+  type PaginationInfo,
+  type PaginatedData,
+  type PaginatedSuccessResponse,
+  type ErrorDetail,
+  type ErrorResponse,
+  type ApiResponse,
+  type HttpStatusType,
+} from "./response";
+
+// バリデーション関連
+export {
+  zodErrorToDetails,
+  validateWithSchema,
+  parseAndValidateBody,
+  searchParamsToObject,
+  validateQueryParams,
+  validatePathParams,
+  CommonSchemas,
+  PaginationQuerySchema,
+  type PaginationQuery,
+} from "./validation";
+
+// ページネーション関連
+export {
+  calculatePagination,
+  calculateOffset,
+  getPaginationParams,
+  normalizePaginationParams,
+  DEFAULT_PAGINATION,
+  type PaginationOptions,
+} from "./pagination";
+
+// ハンドラー関連
+export {
+  withHandler,
+  withAuthHandler,
+  createHandlers,
+  type RouteContext,
+  type RouteHandler,
+  type HandlerOptions,
+} from "./handler";

--- a/src/lib/api/pagination.test.ts
+++ b/src/lib/api/pagination.test.ts
@@ -1,0 +1,382 @@
+/**
+ * ページネーションヘルパーのテスト
+ */
+
+import {
+  calculateOffset,
+  calculatePagination,
+  DEFAULT_PAGINATION,
+  getPaginationParams,
+  normalizePaginationParams,
+} from "./pagination";
+
+describe("calculatePagination", () => {
+  it("基本的なページネーション情報を計算する", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 20,
+      total: 100,
+    });
+
+    expect(result).toEqual({
+      total: 100,
+      per_page: 20,
+      current_page: 1,
+      last_page: 5,
+      from: 1,
+      to: 20,
+    });
+  });
+
+  it("2ページ目の情報を正しく計算する", () => {
+    const result = calculatePagination({
+      page: 2,
+      perPage: 20,
+      total: 100,
+    });
+
+    expect(result).toEqual({
+      total: 100,
+      per_page: 20,
+      current_page: 2,
+      last_page: 5,
+      from: 21,
+      to: 40,
+    });
+  });
+
+  it("最後のページの情報を正しく計算する", () => {
+    const result = calculatePagination({
+      page: 5,
+      perPage: 20,
+      total: 95,
+    });
+
+    expect(result).toEqual({
+      total: 95,
+      per_page: 20,
+      current_page: 5,
+      last_page: 5,
+      from: 81,
+      to: 95,
+    });
+  });
+
+  it("総数が0の場合を正しく処理する", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 20,
+      total: 0,
+    });
+
+    expect(result).toEqual({
+      total: 0,
+      per_page: 20,
+      current_page: 1,
+      last_page: 1,
+      from: 0,
+      to: 0,
+    });
+  });
+
+  it("ページ番号が最後のページを超える場合は調整される", () => {
+    const result = calculatePagination({
+      page: 10,
+      perPage: 20,
+      total: 50,
+    });
+
+    expect(result.current_page).toBe(3);
+    expect(result.last_page).toBe(3);
+  });
+
+  it("負のページ番号は1に調整される", () => {
+    const result = calculatePagination({
+      page: -5,
+      perPage: 20,
+      total: 100,
+    });
+
+    expect(result.current_page).toBe(1);
+  });
+
+  it("負のperPageは1に調整される", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: -10,
+      total: 100,
+    });
+
+    expect(result.per_page).toBe(1);
+    expect(result.last_page).toBe(100);
+  });
+
+  it("負のtotalは0に調整される", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 20,
+      total: -50,
+    });
+
+    expect(result.total).toBe(0);
+  });
+
+  it("小数のページ番号は切り捨てられる", () => {
+    const result = calculatePagination({
+      page: 2.7,
+      perPage: 20,
+      total: 100,
+    });
+
+    expect(result.current_page).toBe(2);
+  });
+
+  it("小数のperPageは切り捨てられる", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 15.9,
+      total: 100,
+    });
+
+    expect(result.per_page).toBe(15);
+  });
+
+  it("1件のみのデータを正しく処理する", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 20,
+      total: 1,
+    });
+
+    expect(result).toEqual({
+      total: 1,
+      per_page: 20,
+      current_page: 1,
+      last_page: 1,
+      from: 1,
+      to: 1,
+    });
+  });
+
+  it("perPageと同じ総数を正しく処理する", () => {
+    const result = calculatePagination({
+      page: 1,
+      perPage: 20,
+      total: 20,
+    });
+
+    expect(result).toEqual({
+      total: 20,
+      per_page: 20,
+      current_page: 1,
+      last_page: 1,
+      from: 1,
+      to: 20,
+    });
+  });
+
+  it("perPageより1件多い総数を正しく処理する", () => {
+    const result = calculatePagination({
+      page: 2,
+      perPage: 20,
+      total: 21,
+    });
+
+    expect(result).toEqual({
+      total: 21,
+      per_page: 20,
+      current_page: 2,
+      last_page: 2,
+      from: 21,
+      to: 21,
+    });
+  });
+});
+
+describe("calculateOffset", () => {
+  it("基本的なオフセットを計算する", () => {
+    const result = calculateOffset(1, 20);
+
+    expect(result).toEqual({
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it("2ページ目のオフセットを計算する", () => {
+    const result = calculateOffset(2, 20);
+
+    expect(result).toEqual({
+      skip: 20,
+      take: 20,
+    });
+  });
+
+  it("3ページ目のオフセットを計算する", () => {
+    const result = calculateOffset(3, 10);
+
+    expect(result).toEqual({
+      skip: 20,
+      take: 10,
+    });
+  });
+
+  it("負のページ番号は1に調整される", () => {
+    const result = calculateOffset(-1, 20);
+
+    expect(result).toEqual({
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it("0のページ番号は1に調整される", () => {
+    const result = calculateOffset(0, 20);
+
+    expect(result).toEqual({
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it("負のperPageは1に調整される", () => {
+    const result = calculateOffset(1, -10);
+
+    expect(result).toEqual({
+      skip: 0,
+      take: 1,
+    });
+  });
+
+  it("小数は切り捨てられる", () => {
+    const result = calculateOffset(2.8, 15.5);
+
+    expect(result).toEqual({
+      skip: 15,
+      take: 15,
+    });
+  });
+});
+
+describe("getPaginationParams", () => {
+  it("calculateOffsetと同じ結果を返す", () => {
+    const result = getPaginationParams({ page: 3, perPage: 25 });
+
+    expect(result).toEqual({
+      skip: 50,
+      take: 25,
+    });
+  });
+});
+
+describe("DEFAULT_PAGINATION", () => {
+  it("デフォルト値が正しく設定されている", () => {
+    expect(DEFAULT_PAGINATION.page).toBe(1);
+    expect(DEFAULT_PAGINATION.perPage).toBe(20);
+    expect(DEFAULT_PAGINATION.maxPerPage).toBe(100);
+  });
+});
+
+describe("normalizePaginationParams", () => {
+  it("有効な数値をそのまま返す", () => {
+    const result = normalizePaginationParams(5, 50);
+
+    expect(result).toEqual({
+      page: 5,
+      perPage: 50,
+    });
+  });
+
+  it("文字列を数値に変換する", () => {
+    const result = normalizePaginationParams("3", "30");
+
+    expect(result).toEqual({
+      page: 3,
+      perPage: 30,
+    });
+  });
+
+  it("undefinedの場合はデフォルト値を使用する", () => {
+    const result = normalizePaginationParams(undefined, undefined);
+
+    expect(result).toEqual({
+      page: DEFAULT_PAGINATION.page,
+      perPage: DEFAULT_PAGINATION.perPage,
+    });
+  });
+
+  it("nullの場合はデフォルト値を使用する", () => {
+    const result = normalizePaginationParams(null, null);
+
+    expect(result).toEqual({
+      page: DEFAULT_PAGINATION.page,
+      perPage: DEFAULT_PAGINATION.perPage,
+    });
+  });
+
+  it("1未満のページ番号はデフォルト値を使用する", () => {
+    const result = normalizePaginationParams(0, 20);
+
+    expect(result.page).toBe(DEFAULT_PAGINATION.page);
+  });
+
+  it("負のページ番号はデフォルト値を使用する", () => {
+    const result = normalizePaginationParams(-1, 20);
+
+    expect(result.page).toBe(DEFAULT_PAGINATION.page);
+  });
+
+  it("1未満のperPageはデフォルト値を使用する", () => {
+    const result = normalizePaginationParams(1, 0);
+
+    expect(result.perPage).toBe(DEFAULT_PAGINATION.perPage);
+  });
+
+  it("maxPerPageを超えるperPageは制限される", () => {
+    const result = normalizePaginationParams(1, 200);
+
+    expect(result.perPage).toBe(DEFAULT_PAGINATION.maxPerPage);
+  });
+
+  it("maxPerPageちょうどの値は許可される", () => {
+    const result = normalizePaginationParams(1, 100);
+
+    expect(result.perPage).toBe(100);
+  });
+
+  it("無効な文字列はデフォルト値を使用する", () => {
+    const result = normalizePaginationParams("abc", "xyz");
+
+    expect(result).toEqual({
+      page: DEFAULT_PAGINATION.page,
+      perPage: DEFAULT_PAGINATION.perPage,
+    });
+  });
+
+  it("小数は切り捨てられる", () => {
+    const result = normalizePaginationParams(2.9, 25.7);
+
+    expect(result).toEqual({
+      page: 2,
+      perPage: 25,
+    });
+  });
+
+  it("pageのみ指定した場合perPageはデフォルト", () => {
+    const result = normalizePaginationParams(5);
+
+    expect(result).toEqual({
+      page: 5,
+      perPage: DEFAULT_PAGINATION.perPage,
+    });
+  });
+
+  it("perPageのみ指定した場合pageはデフォルト", () => {
+    const result = normalizePaginationParams(undefined, 50);
+
+    expect(result).toEqual({
+      page: DEFAULT_PAGINATION.page,
+      perPage: 50,
+    });
+  });
+});

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,0 +1,135 @@
+/**
+ * ページネーションヘルパー
+ *
+ * ページネーションに関するユーティリティ関数を提供します
+ */
+
+import type { PaginationInfo } from "./response";
+
+/**
+ * ページネーションオプション
+ */
+export interface PaginationOptions {
+  /** 現在のページ番号 (1始まり) */
+  page: number;
+  /** 1ページあたりのアイテム数 */
+  perPage: number;
+  /** 総アイテム数 */
+  total: number;
+}
+
+/**
+ * ページネーション情報を計算
+ *
+ * @param options ページネーションオプション
+ * @returns ページネーション情報
+ */
+export function calculatePagination(
+  options: PaginationOptions
+): PaginationInfo {
+  const { page, perPage, total } = options;
+
+  // ページ番号とperPageは正の整数であることを保証
+  const safePage = Math.max(1, Math.floor(page));
+  const safePerPage = Math.max(1, Math.floor(perPage));
+  const safeTotal = Math.max(0, Math.floor(total));
+
+  // 最後のページを計算
+  const lastPage = Math.max(1, Math.ceil(safeTotal / safePerPage));
+
+  // 現在のページが最後のページを超えている場合は調整
+  const currentPage = Math.min(safePage, lastPage);
+
+  // 開始位置と終了位置を計算
+  const from = safeTotal === 0 ? 0 : (currentPage - 1) * safePerPage + 1;
+  const to = Math.min(currentPage * safePerPage, safeTotal);
+
+  return {
+    total: safeTotal,
+    per_page: safePerPage,
+    current_page: currentPage,
+    last_page: lastPage,
+    from,
+    to,
+  };
+}
+
+/**
+ * Prismaのskip/take形式に変換するためのオフセット計算
+ *
+ * @param page ページ番号 (1始まり)
+ * @param perPage 1ページあたりのアイテム数
+ * @returns { skip, take } Prisma形式のオフセット
+ */
+export function calculateOffset(
+  page: number,
+  perPage: number
+): { skip: number; take: number } {
+  const safePage = Math.max(1, Math.floor(page));
+  const safePerPage = Math.max(1, Math.floor(perPage));
+
+  return {
+    skip: (safePage - 1) * safePerPage,
+    take: safePerPage,
+  };
+}
+
+/**
+ * ページネーション付きデータの取得をサポートするヘルパー関数
+ *
+ * @param options ページネーションオプション
+ * @returns ページネーション情報とオフセット
+ */
+export function getPaginationParams(options: {
+  page: number;
+  perPage: number;
+}): {
+  skip: number;
+  take: number;
+} {
+  return calculateOffset(options.page, options.perPage);
+}
+
+/**
+ * デフォルトのページネーション設定
+ */
+export const DEFAULT_PAGINATION = {
+  page: 1,
+  perPage: 20,
+  maxPerPage: 100,
+} as const;
+
+/**
+ * ページネーションパラメータを正規化
+ *
+ * @param page ページ番号（未指定の場合はデフォルト値）
+ * @param perPage 1ページあたりのアイテム数（未指定の場合はデフォルト値）
+ * @returns 正規化されたページネーションパラメータ
+ */
+export function normalizePaginationParams(
+  page?: number | string | null,
+  perPage?: number | string | null
+): { page: number; perPage: number } {
+  let normalizedPage: number = DEFAULT_PAGINATION.page;
+  let normalizedPerPage: number = DEFAULT_PAGINATION.perPage;
+
+  if (page !== undefined && page !== null) {
+    const parsed = typeof page === "string" ? parseInt(page, 10) : page;
+    if (!isNaN(parsed) && parsed >= 1) {
+      normalizedPage = Math.floor(parsed);
+    }
+  }
+
+  if (perPage !== undefined && perPage !== null) {
+    const parsed =
+      typeof perPage === "string" ? parseInt(perPage, 10) : perPage;
+    if (!isNaN(parsed) && parsed >= 1) {
+      normalizedPerPage = Math.min(
+        Math.floor(parsed),
+        DEFAULT_PAGINATION.maxPerPage
+      );
+    }
+  }
+
+  return { page: normalizedPage, perPage: normalizedPerPage };
+}

--- a/src/lib/api/response.test.ts
+++ b/src/lib/api/response.test.ts
@@ -1,0 +1,409 @@
+/**
+ * APIレスポンスヘルパーのテスト
+ */
+
+import { ApiError, ErrorCode } from "./errors";
+import {
+  apiErrorResponse,
+  createdResponse,
+  errorResponse,
+  forbiddenResponse,
+  HttpStatus,
+  internalErrorResponse,
+  notFoundResponse,
+  paginatedResponse,
+  successResponse,
+  unauthorizedResponse,
+  validationErrorResponse,
+} from "./response";
+
+import type { ErrorDetail, PaginationInfo } from "./response";
+
+describe("HttpStatus", () => {
+  it("すべてのHTTPステータスコードが正しく定義されている", () => {
+    expect(HttpStatus.OK).toBe(200);
+    expect(HttpStatus.CREATED).toBe(201);
+    expect(HttpStatus.BAD_REQUEST).toBe(400);
+    expect(HttpStatus.UNAUTHORIZED).toBe(401);
+    expect(HttpStatus.FORBIDDEN).toBe(403);
+    expect(HttpStatus.NOT_FOUND).toBe(404);
+    expect(HttpStatus.UNPROCESSABLE_ENTITY).toBe(422);
+    expect(HttpStatus.INTERNAL_SERVER_ERROR).toBe(500);
+    expect(HttpStatus.SERVICE_UNAVAILABLE).toBe(503);
+  });
+});
+
+describe("successResponse", () => {
+  it("成功レスポンスを正しい形式で生成する", async () => {
+    const data = { id: 1, name: "テスト" };
+    const response = successResponse(data);
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { id: 1, name: "テスト" },
+    });
+  });
+
+  it("メッセージ付きで成功レスポンスを生成できる", async () => {
+    const data = { id: 1 };
+    const response = successResponse(data, { message: "取得に成功しました" });
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { id: 1 },
+      message: "取得に成功しました",
+    });
+  });
+
+  it("カスタムステータスコードを指定できる", async () => {
+    const data = { result: "ok" };
+    const response = successResponse(data, { status: 202 });
+
+    expect(response.status).toBe(202);
+  });
+
+  it("空のデータでも正しくレスポンスを生成できる", async () => {
+    const response = successResponse(null);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: null,
+    });
+  });
+
+  it("配列データを正しく処理できる", async () => {
+    const data = [{ id: 1 }, { id: 2 }];
+    const response = successResponse(data);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: [{ id: 1 }, { id: 2 }],
+    });
+  });
+});
+
+describe("createdResponse", () => {
+  it("201ステータスで作成成功レスポンスを生成する", async () => {
+    const data = { id: 1, name: "新規ユーザー" };
+    const response = createdResponse(data);
+
+    expect(response.status).toBe(201);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { id: 1, name: "新規ユーザー" },
+    });
+  });
+
+  it("メッセージ付きで作成成功レスポンスを生成できる", async () => {
+    const data = { id: 1 };
+    const response = createdResponse(data, "ユーザーを作成しました");
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { id: 1 },
+      message: "ユーザーを作成しました",
+    });
+  });
+});
+
+describe("paginatedResponse", () => {
+  it("ページネーション付きレスポンスを正しい形式で生成する", async () => {
+    const items = [{ id: 1 }, { id: 2 }];
+    const pagination: PaginationInfo = {
+      total: 100,
+      per_page: 20,
+      current_page: 1,
+      last_page: 5,
+      from: 1,
+      to: 20,
+    };
+    const response = paginatedResponse(items, pagination);
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: {
+        items: [{ id: 1 }, { id: 2 }],
+        pagination: {
+          total: 100,
+          per_page: 20,
+          current_page: 1,
+          last_page: 5,
+          from: 1,
+          to: 20,
+        },
+      },
+    });
+  });
+
+  it("空の配列でもページネーション情報を正しく返す", async () => {
+    const items: unknown[] = [];
+    const pagination: PaginationInfo = {
+      total: 0,
+      per_page: 20,
+      current_page: 1,
+      last_page: 1,
+      from: 0,
+      to: 0,
+    };
+    const response = paginatedResponse(items, pagination);
+
+    const body = await response.json();
+    expect(body.data.items).toEqual([]);
+    expect(body.data.pagination.total).toBe(0);
+  });
+});
+
+describe("errorResponse", () => {
+  it("エラーレスポンスを正しい形式で生成する", async () => {
+    const response = errorResponse(
+      ErrorCode.RESOURCE_NOT_FOUND,
+      "ユーザーが見つかりません"
+    );
+
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "RESOURCE_NOT_FOUND",
+        message: "ユーザーが見つかりません",
+      },
+    });
+  });
+
+  it("詳細情報付きでエラーレスポンスを生成できる", async () => {
+    const details: ErrorDetail[] = [
+      { field: "email", message: "メールアドレスが無効です" },
+      {
+        field: "password",
+        message: "パスワードは8文字以上必要です",
+        code: "min_length",
+      },
+    ];
+    const response = errorResponse(
+      ErrorCode.VALIDATION_ERROR,
+      "入力内容に誤りがあります",
+      details
+    );
+
+    expect(response.status).toBe(422);
+
+    const body = await response.json();
+    expect(body.error.details).toEqual(details);
+  });
+
+  it("カスタムステータスコードを指定できる", async () => {
+    const response = errorResponse(
+      ErrorCode.INTERNAL_ERROR,
+      "エラー",
+      undefined,
+      502
+    );
+
+    expect(response.status).toBe(502);
+  });
+
+  it("空のdetails配列はレスポンスに含まれない", async () => {
+    const response = errorResponse(ErrorCode.VALIDATION_ERROR, "エラー", []);
+
+    const body = await response.json();
+    expect(body.error.details).toBeUndefined();
+  });
+});
+
+describe("apiErrorResponse", () => {
+  it("ApiErrorからエラーレスポンスを生成する", async () => {
+    const error = new ApiError(
+      ErrorCode.RESOURCE_NOT_FOUND,
+      "ユーザーが見つかりません"
+    );
+    const response = apiErrorResponse(error);
+
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "RESOURCE_NOT_FOUND",
+        message: "ユーザーが見つかりません",
+      },
+    });
+  });
+
+  it("詳細情報付きApiErrorを正しく処理する", async () => {
+    const details = [
+      {
+        field: "email",
+        message: "メールアドレスが無効です",
+        code: "invalid_email",
+      },
+    ];
+    const error = new ApiError(
+      ErrorCode.VALIDATION_ERROR,
+      "入力エラー",
+      details
+    );
+    const response = apiErrorResponse(error);
+
+    const body = await response.json();
+    expect(body.error.details).toEqual(details);
+  });
+
+  it("文字列の詳細情報を正しく変換する", async () => {
+    const error = new ApiError(ErrorCode.VALIDATION_ERROR, "エラー", [
+      "エラー詳細1",
+      "エラー詳細2",
+    ]);
+    const response = apiErrorResponse(error);
+
+    const body = await response.json();
+    expect(body.error.details).toEqual([
+      { message: "エラー詳細1" },
+      { message: "エラー詳細2" },
+    ]);
+  });
+});
+
+describe("validationErrorResponse", () => {
+  it("バリデーションエラーレスポンスを生成する", async () => {
+    const details: ErrorDetail[] = [
+      { field: "email", message: "メールアドレスが無効です" },
+    ];
+    const response = validationErrorResponse(details);
+
+    expect(response.status).toBe(422);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "入力内容に誤りがあります",
+        details,
+      },
+    });
+  });
+
+  it("カスタムメッセージを指定できる", async () => {
+    const details: ErrorDetail[] = [
+      { field: "name", message: "名前は必須です" },
+    ];
+    const response = validationErrorResponse(
+      details,
+      "フォームにエラーがあります"
+    );
+
+    const body = await response.json();
+    expect(body.error.message).toBe("フォームにエラーがあります");
+  });
+});
+
+describe("unauthorizedResponse", () => {
+  it("認証エラーレスポンスを生成する", async () => {
+    const response = unauthorizedResponse();
+
+    expect(response.status).toBe(401);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "AUTH_UNAUTHORIZED",
+        message: "認証が必要です",
+      },
+    });
+  });
+
+  it("カスタムメッセージを指定できる", async () => {
+    const response = unauthorizedResponse("ログインが必要です");
+
+    const body = await response.json();
+    expect(body.error.message).toBe("ログインが必要です");
+  });
+});
+
+describe("forbiddenResponse", () => {
+  it("権限エラーレスポンスを生成する", async () => {
+    const response = forbiddenResponse();
+
+    expect(response.status).toBe(403);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "FORBIDDEN_ACCESS",
+        message: "このリソースへのアクセス権限がありません",
+      },
+    });
+  });
+
+  it("カスタムメッセージを指定できる", async () => {
+    const response = forbiddenResponse("管理者権限が必要です");
+
+    const body = await response.json();
+    expect(body.error.message).toBe("管理者権限が必要です");
+  });
+});
+
+describe("notFoundResponse", () => {
+  it("リソース未検出エラーレスポンスを生成する", async () => {
+    const response = notFoundResponse();
+
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "RESOURCE_NOT_FOUND",
+        message: "指定されたリソースが見つかりません",
+      },
+    });
+  });
+
+  it("カスタムメッセージを指定できる", async () => {
+    const response = notFoundResponse("ユーザーが見つかりません");
+
+    const body = await response.json();
+    expect(body.error.message).toBe("ユーザーが見つかりません");
+  });
+});
+
+describe("internalErrorResponse", () => {
+  it("内部エラーレスポンスを生成する", async () => {
+    const response = internalErrorResponse();
+
+    expect(response.status).toBe(500);
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "サーバー内部エラーが発生しました",
+      },
+    });
+  });
+
+  it("カスタムメッセージを指定できる", async () => {
+    const response = internalErrorResponse("データベース接続エラー");
+
+    const body = await response.json();
+    expect(body.error.message).toBe("データベース接続エラー");
+  });
+});

--- a/src/lib/api/response.ts
+++ b/src/lib/api/response.ts
@@ -1,0 +1,319 @@
+/**
+ * APIレスポンスヘルパー
+ *
+ * 統一されたAPIレスポンス形式を提供します
+ */
+
+import { NextResponse } from "next/server";
+
+import { ErrorCode, ErrorCodeToHttpStatus } from "./errors";
+
+import type { ApiError, ErrorCodeType } from "./errors";
+
+/**
+ * 成功レスポンスの型定義
+ */
+export interface SuccessResponse<T> {
+  success: true;
+  data: T;
+  message?: string;
+}
+
+/**
+ * ページネーション情報の型定義
+ */
+export interface PaginationInfo {
+  /** 総アイテム数 */
+  total: number;
+  /** 1ページあたりのアイテム数 */
+  per_page: number;
+  /** 現在のページ番号 (1始まり) */
+  current_page: number;
+  /** 最後のページ番号 */
+  last_page: number;
+  /** 現在のページの開始位置 (1始まり) */
+  from: number;
+  /** 現在のページの終了位置 */
+  to: number;
+}
+
+/**
+ * ページネーション付きレスポンスデータの型定義
+ */
+export interface PaginatedData<T> {
+  items: T[];
+  pagination: PaginationInfo;
+}
+
+/**
+ * ページネーション付き成功レスポンスの型定義
+ */
+export interface PaginatedSuccessResponse<T> {
+  success: true;
+  data: PaginatedData<T>;
+}
+
+/**
+ * エラーレスポンスの詳細情報
+ */
+export interface ErrorDetail {
+  field?: string;
+  message: string;
+  code?: string;
+}
+
+/**
+ * エラーレスポンスの型定義
+ */
+export interface ErrorResponse {
+  success: false;
+  error: {
+    code: ErrorCodeType;
+    message: string;
+    details?: ErrorDetail[];
+  };
+}
+
+/**
+ * APIレスポンスの統一型
+ */
+export type ApiResponse<T> =
+  | SuccessResponse<T>
+  | PaginatedSuccessResponse<T>
+  | ErrorResponse;
+
+/**
+ * HTTPステータスコード定義
+ */
+export const HttpStatus = {
+  OK: 200,
+  CREATED: 201,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  UNPROCESSABLE_ENTITY: 422,
+  INTERNAL_SERVER_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+export type HttpStatusType = (typeof HttpStatus)[keyof typeof HttpStatus];
+
+/**
+ * 成功レスポンスを生成
+ *
+ * @param data レスポンスデータ
+ * @param options オプション（message, status）
+ * @returns NextResponse
+ */
+export function successResponse<T>(
+  data: T,
+  options?: {
+    message?: string;
+    status?: number;
+  }
+): NextResponse<SuccessResponse<T>> {
+  const { message, status = HttpStatus.OK } = options ?? {};
+
+  const responseBody: SuccessResponse<T> = {
+    success: true,
+    data,
+  };
+
+  if (message) {
+    responseBody.message = message;
+  }
+
+  return NextResponse.json(responseBody, { status });
+}
+
+/**
+ * 作成成功レスポンスを生成（201 Created）
+ *
+ * @param data 作成されたリソースデータ
+ * @param message オプションのメッセージ
+ * @returns NextResponse
+ */
+export function createdResponse<T>(
+  data: T,
+  message?: string
+): NextResponse<SuccessResponse<T>> {
+  const options: { message?: string; status: number } = {
+    status: HttpStatus.CREATED,
+  };
+  if (message !== undefined) {
+    options.message = message;
+  }
+  return successResponse(data, options);
+}
+
+/**
+ * ページネーション付き成功レスポンスを生成
+ *
+ * @param items アイテムの配列
+ * @param pagination ページネーション情報
+ * @returns NextResponse
+ */
+export function paginatedResponse<T>(
+  items: T[],
+  pagination: PaginationInfo
+): NextResponse<PaginatedSuccessResponse<T>> {
+  const responseBody: PaginatedSuccessResponse<T> = {
+    success: true,
+    data: {
+      items,
+      pagination,
+    },
+  };
+
+  return NextResponse.json(responseBody, { status: HttpStatus.OK });
+}
+
+/**
+ * エラーレスポンスを生成
+ *
+ * @param code エラーコード
+ * @param message エラーメッセージ
+ * @param details エラー詳細
+ * @param status HTTPステータスコード（省略時はエラーコードから自動決定）
+ * @returns NextResponse
+ */
+export function errorResponse(
+  code: ErrorCodeType,
+  message: string,
+  details?: ErrorDetail[],
+  status?: number
+): NextResponse<ErrorResponse> {
+  const responseBody: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+    },
+  };
+
+  if (details && details.length > 0) {
+    responseBody.error.details = details;
+  }
+
+  const httpStatus = status ?? ErrorCodeToHttpStatus[code];
+
+  return NextResponse.json(responseBody, { status: httpStatus });
+}
+
+/**
+ * ApiErrorからエラーレスポンスを生成
+ *
+ * @param error ApiErrorインスタンス
+ * @returns NextResponse
+ */
+export function apiErrorResponse(error: ApiError): NextResponse<ErrorResponse> {
+  const details: ErrorDetail[] | undefined = error.details?.map((detail) => {
+    if (typeof detail === "string") {
+      return { message: detail };
+    }
+    if (typeof detail === "object" && detail !== null) {
+      const obj = detail as Record<string, unknown>;
+      const result: ErrorDetail = {
+        message: typeof obj.message === "string" ? obj.message : String(detail),
+      };
+      if (typeof obj.field === "string") {
+        result.field = obj.field;
+      }
+      if (typeof obj.code === "string") {
+        result.code = obj.code;
+      }
+      return result;
+    }
+    return { message: String(detail) };
+  });
+
+  return errorResponse(error.code, error.message, details, error.statusCode);
+}
+
+/**
+ * バリデーションエラーレスポンスを生成
+ *
+ * @param details バリデーションエラーの詳細
+ * @param message オプションのエラーメッセージ
+ * @returns NextResponse
+ */
+export function validationErrorResponse(
+  details: ErrorDetail[],
+  message = "入力内容に誤りがあります"
+): NextResponse<ErrorResponse> {
+  return errorResponse(
+    ErrorCode.VALIDATION_ERROR,
+    message,
+    details,
+    HttpStatus.UNPROCESSABLE_ENTITY
+  );
+}
+
+/**
+ * 認証エラーレスポンスを生成
+ *
+ * @param message オプションのエラーメッセージ
+ * @returns NextResponse
+ */
+export function unauthorizedResponse(
+  message = "認証が必要です"
+): NextResponse<ErrorResponse> {
+  return errorResponse(
+    ErrorCode.AUTH_UNAUTHORIZED,
+    message,
+    undefined,
+    HttpStatus.UNAUTHORIZED
+  );
+}
+
+/**
+ * 権限エラーレスポンスを生成
+ *
+ * @param message オプションのエラーメッセージ
+ * @returns NextResponse
+ */
+export function forbiddenResponse(
+  message = "このリソースへのアクセス権限がありません"
+): NextResponse<ErrorResponse> {
+  return errorResponse(
+    ErrorCode.FORBIDDEN_ACCESS,
+    message,
+    undefined,
+    HttpStatus.FORBIDDEN
+  );
+}
+
+/**
+ * リソース未検出エラーレスポンスを生成
+ *
+ * @param message オプションのエラーメッセージ
+ * @returns NextResponse
+ */
+export function notFoundResponse(
+  message = "指定されたリソースが見つかりません"
+): NextResponse<ErrorResponse> {
+  return errorResponse(
+    ErrorCode.RESOURCE_NOT_FOUND,
+    message,
+    undefined,
+    HttpStatus.NOT_FOUND
+  );
+}
+
+/**
+ * 内部エラーレスポンスを生成
+ *
+ * @param message オプションのエラーメッセージ
+ * @returns NextResponse
+ */
+export function internalErrorResponse(
+  message = "サーバー内部エラーが発生しました"
+): NextResponse<ErrorResponse> {
+  return errorResponse(
+    ErrorCode.INTERNAL_ERROR,
+    message,
+    undefined,
+    HttpStatus.INTERNAL_SERVER_ERROR
+  );
+}

--- a/src/lib/api/validation.test.ts
+++ b/src/lib/api/validation.test.ts
@@ -1,0 +1,556 @@
+/**
+ * Zodバリデーション共通処理のテスト
+ */
+
+import { z } from "zod";
+
+import { ApiError, ErrorCode } from "./errors";
+import {
+  CommonSchemas,
+  PaginationQuerySchema,
+  parseAndValidateBody,
+  searchParamsToObject,
+  validatePathParams,
+  validateQueryParams,
+  validateWithSchema,
+  zodErrorToDetails,
+} from "./validation";
+
+describe("zodErrorToDetails", () => {
+  it("Zodエラーを正しい形式に変換する", () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = schema.safeParse({ name: 123, age: "invalid" });
+
+    if (result.success) {
+      throw new Error("バリデーションが成功すべきではない");
+    }
+
+    const details = zodErrorToDetails(result.error);
+
+    expect(details.length).toBe(2);
+    expect(details[0]).toEqual({
+      field: "name",
+      message: expect.any(String),
+      code: "invalid_type",
+    });
+    expect(details[1]).toEqual({
+      field: "age",
+      message: expect.any(String),
+      code: "invalid_type",
+    });
+  });
+
+  it("ネストしたパスを正しく変換する", () => {
+    const schema = z.object({
+      user: z.object({
+        profile: z.object({
+          email: z.string().email(),
+        }),
+      }),
+    });
+
+    const result = schema.safeParse({
+      user: { profile: { email: "invalid" } },
+    });
+
+    if (result.success) {
+      throw new Error("バリデーションが成功すべきではない");
+    }
+
+    const details = zodErrorToDetails(result.error);
+
+    expect(details[0]?.field).toBe("user.profile.email");
+  });
+
+  it("配列のインデックスを含むパスを変換する", () => {
+    const schema = z.object({
+      items: z.array(z.string()),
+    });
+
+    const result = schema.safeParse({
+      items: ["valid", 123, "also valid"],
+    });
+
+    if (result.success) {
+      throw new Error("バリデーションが成功すべきではない");
+    }
+
+    const details = zodErrorToDetails(result.error);
+
+    expect(details[0]?.field).toBe("items.1");
+  });
+});
+
+describe("validateWithSchema", () => {
+  it("有効なデータをそのまま返す", () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const data = { name: "山田太郎", age: 30 };
+    const result = validateWithSchema(schema, data);
+
+    expect(result).toEqual(data);
+  });
+
+  it("無効なデータの場合ApiErrorをスローする", () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    expect(() => validateWithSchema(schema, { name: 123 })).toThrow(ApiError);
+  });
+
+  it("スローされるApiErrorが正しいコードを持つ", () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    try {
+      validateWithSchema(schema, { name: 123 });
+      throw new Error("例外がスローされるべき");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      if (error instanceof ApiError) {
+        expect(error.code).toBe(ErrorCode.VALIDATION_ERROR);
+        expect(error.statusCode).toBe(422);
+        expect(error.details).toBeDefined();
+      }
+    }
+  });
+
+  it("スキーマの変換が適用される", () => {
+    const schema = z.object({
+      count: z.coerce.number(),
+    });
+
+    const result = validateWithSchema(schema, { count: "42" });
+
+    expect(result.count).toBe(42);
+  });
+});
+
+describe("parseAndValidateBody", () => {
+  it("有効なJSONボディをパースして検証する", async () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    const request = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ name: "テスト" }),
+    });
+
+    const result = await parseAndValidateBody(request, schema);
+
+    expect(result).toEqual({ name: "テスト" });
+  });
+
+  it("無効なJSONの場合ApiErrorをスローする", async () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    const request = new Request("http://localhost", {
+      method: "POST",
+      body: "invalid json",
+    });
+
+    await expect(parseAndValidateBody(request, schema)).rejects.toThrow(
+      ApiError
+    );
+  });
+
+  it("JSONパースエラー時の正しいエラーメッセージ", async () => {
+    const schema = z.object({});
+
+    const request = new Request("http://localhost", {
+      method: "POST",
+      body: "not json",
+    });
+
+    try {
+      await parseAndValidateBody(request, schema);
+      throw new Error("例外がスローされるべき");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      if (error instanceof ApiError) {
+        expect(error.message).toBe(
+          "リクエストボディのJSONパースに失敗しました"
+        );
+      }
+    }
+  });
+
+  it("バリデーションエラーの場合ApiErrorをスローする", async () => {
+    const schema = z.object({
+      email: z.string().email(),
+    });
+
+    const request = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ email: "invalid" }),
+    });
+
+    await expect(parseAndValidateBody(request, schema)).rejects.toThrow(
+      ApiError
+    );
+  });
+});
+
+describe("searchParamsToObject", () => {
+  it("URLSearchParamsをオブジェクトに変換する", () => {
+    const params = new URLSearchParams("name=test&page=1");
+    const result = searchParamsToObject(params);
+
+    expect(result).toEqual({
+      name: "test",
+      page: "1",
+    });
+  });
+
+  it("同じキーが複数ある場合は配列にする", () => {
+    const params = new URLSearchParams(
+      "tag=javascript&tag=typescript&tag=react"
+    );
+    const result = searchParamsToObject(params);
+
+    expect(result).toEqual({
+      tag: ["javascript", "typescript", "react"],
+    });
+  });
+
+  it("空のURLSearchParamsは空オブジェクトを返す", () => {
+    const params = new URLSearchParams("");
+    const result = searchParamsToObject(params);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe("validateQueryParams", () => {
+  it("クエリパラメータを検証してパースする", () => {
+    const schema = z.object({
+      page: z.coerce.number(),
+      search: z.string().optional(),
+    });
+
+    const params = new URLSearchParams("page=2&search=test");
+    const result = validateQueryParams(params, schema);
+
+    expect(result).toEqual({
+      page: 2,
+      search: "test",
+    });
+  });
+
+  it("無効なパラメータの場合ApiErrorをスローする", () => {
+    const schema = z.object({
+      page: z.coerce.number().positive(),
+    });
+
+    const params = new URLSearchParams("page=-1");
+
+    expect(() => validateQueryParams(params, schema)).toThrow(ApiError);
+  });
+});
+
+describe("validatePathParams", () => {
+  it("パスパラメータを検証する", () => {
+    const schema = z.object({
+      id: z.string().uuid(),
+    });
+
+    const params = { id: "550e8400-e29b-41d4-a716-446655440000" };
+    const result = validatePathParams(params, schema);
+
+    expect(result).toEqual(params);
+  });
+
+  it("無効なパスパラメータの場合ApiErrorをスローする", () => {
+    const schema = z.object({
+      id: z.string().uuid(),
+    });
+
+    const params = { id: "not-a-uuid" };
+
+    expect(() => validatePathParams(params, schema)).toThrow(ApiError);
+  });
+});
+
+describe("CommonSchemas", () => {
+  describe("uuid", () => {
+    it("有効なUUIDを受け入れる", () => {
+      const result = CommonSchemas.uuid.safeParse(
+        "550e8400-e29b-41d4-a716-446655440000"
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("無効なUUIDを拒否する", () => {
+      const result = CommonSchemas.uuid.safeParse("not-a-uuid");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("positiveInt", () => {
+    it("正の整数を受け入れる", () => {
+      const result = CommonSchemas.positiveInt.safeParse(42);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(42);
+      }
+    });
+
+    it("文字列を数値に変換する", () => {
+      const result = CommonSchemas.positiveInt.safeParse("42");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(42);
+      }
+    });
+
+    it("0を拒否する", () => {
+      const result = CommonSchemas.positiveInt.safeParse(0);
+      expect(result.success).toBe(false);
+    });
+
+    it("負の数を拒否する", () => {
+      const result = CommonSchemas.positiveInt.safeParse(-1);
+      expect(result.success).toBe(false);
+    });
+
+    it("小数を拒否する", () => {
+      const result = CommonSchemas.positiveInt.safeParse(3.14);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("page", () => {
+    it("有効なページ番号を受け入れる", () => {
+      const result = CommonSchemas.page.safeParse(5);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(5);
+      }
+    });
+
+    it("デフォルト値として1を使用する", () => {
+      const result = CommonSchemas.page.safeParse(undefined);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(1);
+      }
+    });
+
+    it("0を拒否する", () => {
+      const result = CommonSchemas.page.safeParse(0);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("perPage", () => {
+    it("有効な表示件数を受け入れる", () => {
+      const result = CommonSchemas.perPage.safeParse(50);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(50);
+      }
+    });
+
+    it("デフォルト値として20を使用する", () => {
+      const result = CommonSchemas.perPage.safeParse(undefined);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(20);
+      }
+    });
+
+    it("100を超える値を拒否する", () => {
+      const result = CommonSchemas.perPage.safeParse(101);
+      expect(result.success).toBe(false);
+    });
+
+    it("0を拒否する", () => {
+      const result = CommonSchemas.perPage.safeParse(0);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("email", () => {
+    it("有効なメールアドレスを受け入れる", () => {
+      const result = CommonSchemas.email.safeParse("test@example.com");
+      expect(result.success).toBe(true);
+    });
+
+    it("無効なメールアドレスを拒否する", () => {
+      const result = CommonSchemas.email.safeParse("invalid-email");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("requiredString", () => {
+    it("空でない文字列を受け入れる", () => {
+      const result = CommonSchemas.requiredString.safeParse("hello");
+      expect(result.success).toBe(true);
+    });
+
+    it("空文字列を拒否する", () => {
+      const result = CommonSchemas.requiredString.safeParse("");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("optionalString", () => {
+    it("文字列を受け入れる", () => {
+      const result = CommonSchemas.optionalString.safeParse("hello");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("hello");
+      }
+    });
+
+    it("空文字列をundefinedに変換する", () => {
+      const result = CommonSchemas.optionalString.safeParse("");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeUndefined();
+      }
+    });
+
+    it("undefinedを受け入れる", () => {
+      const result = CommonSchemas.optionalString.safeParse(undefined);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeUndefined();
+      }
+    });
+  });
+
+  describe("dateString", () => {
+    it("有効なISO 8601形式の日時を受け入れる", () => {
+      const result = CommonSchemas.dateString.safeParse(
+        "2024-01-15T10:30:00.000Z"
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("無効な日時形式を拒否する", () => {
+      const result = CommonSchemas.dateString.safeParse("2024-01-15");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("dateOnly", () => {
+    it("有効なYYYY-MM-DD形式を受け入れる", () => {
+      const result = CommonSchemas.dateOnly.safeParse("2024-01-15");
+      expect(result.success).toBe(true);
+    });
+
+    it("無効な形式を拒否する", () => {
+      const result = CommonSchemas.dateOnly.safeParse("2024/01/15");
+      expect(result.success).toBe(false);
+    });
+
+    it("日時形式を拒否する", () => {
+      const result = CommonSchemas.dateOnly.safeParse("2024-01-15T10:30:00Z");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("sortOrder", () => {
+    it("ascを受け入れる", () => {
+      const result = CommonSchemas.sortOrder.safeParse("asc");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("asc");
+      }
+    });
+
+    it("descを受け入れる", () => {
+      const result = CommonSchemas.sortOrder.safeParse("desc");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("desc");
+      }
+    });
+
+    it("デフォルト値としてdescを使用する", () => {
+      const result = CommonSchemas.sortOrder.safeParse(undefined);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("desc");
+      }
+    });
+
+    it("無効な値を拒否する", () => {
+      const result = CommonSchemas.sortOrder.safeParse("ascending");
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("PaginationQuerySchema", () => {
+  it("有効なページネーションパラメータを受け入れる", () => {
+    const result = PaginationQuerySchema.safeParse({
+      page: 2,
+      per_page: 50,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        page: 2,
+        per_page: 50,
+      });
+    }
+  });
+
+  it("文字列を数値に変換する", () => {
+    const result = PaginationQuerySchema.safeParse({
+      page: "3",
+      per_page: "25",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        page: 3,
+        per_page: 25,
+      });
+    }
+  });
+
+  it("デフォルト値を適用する", () => {
+    const result = PaginationQuerySchema.safeParse({});
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        page: 1,
+        per_page: 20,
+      });
+    }
+  });
+
+  it("無効なページ番号を拒否する", () => {
+    const result = PaginationQuerySchema.safeParse({
+      page: 0,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("範囲外のper_pageを拒否する", () => {
+    const result = PaginationQuerySchema.safeParse({
+      per_page: 200,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/api/validation.ts
+++ b/src/lib/api/validation.ts
@@ -1,0 +1,196 @@
+/**
+ * Zodバリデーション共通処理
+ *
+ * Zodスキーマを使用したリクエストボディのバリデーションを提供します
+ */
+
+import { z } from "zod";
+
+import { ApiError, ErrorCode } from "./errors";
+
+import type { ErrorDetail } from "./response";
+import type { ZodError, ZodSchema } from "zod";
+
+/**
+ * ZodエラーをAPIエラー詳細形式に変換
+ *
+ * @param zodError Zodのエラーオブジェクト
+ * @returns ErrorDetail配列
+ */
+export function zodErrorToDetails(zodError: ZodError): ErrorDetail[] {
+  return zodError.issues.map((issue) => ({
+    field: issue.path.join("."),
+    message: issue.message,
+    code: issue.code,
+  }));
+}
+
+/**
+ * Zodスキーマでデータをバリデーション
+ *
+ * @param schema Zodスキーマ
+ * @param data バリデーション対象のデータ
+ * @returns バリデーション済みデータ
+ * @throws ApiError バリデーションエラー時
+ */
+export function validateWithSchema<T>(schema: ZodSchema<T>, data: unknown): T {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    const details = zodErrorToDetails(result.error);
+    throw new ApiError(
+      ErrorCode.VALIDATION_ERROR,
+      "入力内容に誤りがあります",
+      details
+    );
+  }
+
+  return result.data;
+}
+
+/**
+ * リクエストボディのJSONパースとバリデーション
+ *
+ * @param request Request オブジェクト
+ * @param schema Zodスキーマ
+ * @returns バリデーション済みデータ
+ * @throws ApiError JSONパースエラーまたはバリデーションエラー時
+ */
+export async function parseAndValidateBody<T>(
+  request: Request,
+  schema: ZodSchema<T>
+): Promise<T> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    throw new ApiError(
+      ErrorCode.VALIDATION_ERROR,
+      "リクエストボディのJSONパースに失敗しました"
+    );
+  }
+
+  return validateWithSchema(schema, body);
+}
+
+/**
+ * URLSearchParamsをオブジェクトに変換
+ *
+ * @param searchParams URLSearchParams
+ * @returns パラメータオブジェクト
+ */
+export function searchParamsToObject(
+  searchParams: URLSearchParams
+): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+
+  searchParams.forEach((value, key) => {
+    const existing = result[key];
+    if (existing !== undefined) {
+      // 同じキーが複数ある場合は配列にする
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        result[key] = [existing, value];
+      }
+    } else {
+      result[key] = value;
+    }
+  });
+
+  return result;
+}
+
+/**
+ * クエリパラメータのバリデーション
+ *
+ * @param searchParams URLSearchParams
+ * @param schema Zodスキーマ
+ * @returns バリデーション済みデータ
+ * @throws ApiError バリデーションエラー時
+ */
+export function validateQueryParams<T>(
+  searchParams: URLSearchParams,
+  schema: ZodSchema<T>
+): T {
+  const params = searchParamsToObject(searchParams);
+  return validateWithSchema(schema, params);
+}
+
+/**
+ * パスパラメータのバリデーション
+ *
+ * @param params パスパラメータオブジェクト
+ * @param schema Zodスキーマ
+ * @returns バリデーション済みデータ
+ * @throws ApiError バリデーションエラー時
+ */
+export function validatePathParams<T>(
+  params: Record<string, string | string[]>,
+  schema: ZodSchema<T>
+): T {
+  return validateWithSchema(schema, params);
+}
+
+/**
+ * 共通のバリデーションスキーマ
+ */
+export const CommonSchemas = {
+  /** ID (UUID形式) */
+  uuid: z.string().uuid("有効なUUID形式で入力してください"),
+
+  /** ID (正の整数) */
+  positiveInt: z.coerce
+    .number()
+    .int("整数で入力してください")
+    .positive("正の整数で入力してください"),
+
+  /** ページ番号 */
+  page: z.coerce
+    .number()
+    .int("ページ番号は整数で入力してください")
+    .min(1, "ページ番号は1以上で入力してください")
+    .default(1),
+
+  /** 1ページあたりのアイテム数 */
+  perPage: z.coerce
+    .number()
+    .int("表示件数は整数で入力してください")
+    .min(1, "表示件数は1以上で入力してください")
+    .max(100, "表示件数は100以下で入力してください")
+    .default(20),
+
+  /** メールアドレス */
+  email: z.string().email("有効なメールアドレスを入力してください"),
+
+  /** 必須文字列 */
+  requiredString: z.string().min(1, "この項目は必須です"),
+
+  /** オプション文字列 (空文字を null として扱う) */
+  optionalString: z
+    .string()
+    .optional()
+    .transform((val) => (val === "" ? undefined : val)),
+
+  /** 日付文字列 (ISO 8601形式) */
+  dateString: z.string().datetime("有効な日時形式で入力してください"),
+
+  /** 日付のみ (YYYY-MM-DD形式) */
+  dateOnly: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD形式で入力してください"),
+
+  /** ソート順 */
+  sortOrder: z.enum(["asc", "desc"]).default("desc"),
+};
+
+/**
+ * ページネーションクエリパラメータのスキーマ
+ */
+export const PaginationQuerySchema = z.object({
+  page: CommonSchemas.page,
+  per_page: CommonSchemas.perPage,
+});
+
+export type PaginationQuery = z.infer<typeof PaginationQuerySchema>;


### PR DESCRIPTION
## Summary

- Issue #24で要求されたAPI共通基盤を実装
- 統一されたAPIレスポンス形式（成功/エラー/ページネーション）を提供
- Zodバリデーションと連携したエラーハンドリング機構を実装
- 166件の単体テストで品質を担保

## 実装内容

### エラー定義 (`src/lib/api/errors.ts`)
- エラーコード定義: AUTH_*, FORBIDDEN_*, VALIDATION_*, RESOURCE_*, INTERNAL_*
- ErrorCodeToHttpStatus: エラーコードからHTTPステータスへのマッピング
- ApiErrorクラス: カスタムエラークラス
- createApiError: 便利なエラー生成ヘルパー

### レスポンスヘルパー (`src/lib/api/response.ts`)
- `successResponse`: 通常の成功レスポンス (200)
- `createdResponse`: リソース作成成功 (201)
- `paginatedResponse`: ページネーション付きレスポンス
- `errorResponse`, `apiErrorResponse`: エラーレスポンス
- ショートカット関数: `unauthorizedResponse`, `forbiddenResponse`, `notFoundResponse`, `internalErrorResponse`

### バリデーション (`src/lib/api/validation.ts`)
- `zodErrorToDetails`: ZodエラーをAPI形式に変換
- `validateWithSchema`: スキーマバリデーション
- `parseAndValidateBody`: リクエストボディのパースと検証
- `CommonSchemas`: 共通スキーマ（uuid, positiveInt, page, perPage, email等）

### ページネーション (`src/lib/api/pagination.ts`)
- `calculatePagination`: ページネーション情報の計算
- `calculateOffset`: Prisma用のskip/take計算
- `normalizePaginationParams`: パラメータの正規化

### ハンドラーラッパー (`src/lib/api/handler.ts`)
- `withHandler`: エラーハンドリング付きルートハンドラー
- `withAuthHandler`: 認証付きハンドラー
- `createHandlers`: 複数HTTPメソッド対応

## レスポンス形式

### 成功時
```json
{
  "success": true,
  "data": { ... },
  "message": "処理が完了しました"
}
```

### ページネーション付き
```json
{
  "success": true,
  "data": {
    "items": [ ... ],
    "pagination": {
      "total": 100,
      "per_page": 20,
      "current_page": 1,
      "last_page": 5,
      "from": 1,
      "to": 20
    }
  }
}
```

### エラー時
```json
{
  "success": false,
  "error": {
    "code": "ERROR_CODE",
    "message": "エラーメッセージ",
    "details": [ ... ]
  }
}
```

## Test plan

- [x] errors.test.ts: 32テストケース
- [x] response.test.ts: 27テストケース
- [x] validation.test.ts: 53テストケース
- [x] pagination.test.ts: 35テストケース
- [x] handler.test.ts: 19テストケース
- [x] TypeScriptの型チェックがパス
- [x] ESLintチェックがパス

Closes #24

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)