### PR TITLE
feat: Issue #9 顧客マスタAPIの実装

### DIFF
--- a/src/app/api/v1/customers/[id]/route.ts
+++ b/src/app/api/v1/customers/[id]/route.ts
@@ -1,0 +1,242 @@
+/**
+ * 顧客マスタAPI - 詳細取得・更新・削除
+ *
+ * GET /api/v1/customers/{id} - 顧客詳細取得
+ * PUT /api/v1/customers/{id} - 顧客更新
+ * DELETE /api/v1/customers/{id} - 顧客削除
+ */
+
+import { ErrorCode } from "@/lib/api/errors";
+import {
+  successResponse,
+  errorResponse,
+  notFoundResponse,
+  validationErrorResponse,
+  internalErrorResponse,
+} from "@/lib/api/response";
+import { prisma } from "@/lib/prisma";
+import {
+  customerIdSchema,
+  updateCustomerSchema,
+} from "@/lib/validations/customer";
+
+import type { ErrorDetail } from "@/lib/api/response";
+import type { NextRequest } from "next/server";
+
+/**
+ * Prisma CustomerモデルをAPIレスポンス形式に変換
+ */
+interface CustomerResponse {
+  customer_id: number;
+  customer_name: string;
+  address: string | null;
+  phone: string | null;
+  contact_person: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toCustomerResponse(customer: {
+  id: number;
+  customerName: string;
+  address: string | null;
+  phone: string | null;
+  contactPerson: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): CustomerResponse {
+  return {
+    customer_id: customer.id,
+    customer_name: customer.customerName,
+    address: customer.address,
+    phone: customer.phone,
+    contact_person: customer.contactPerson,
+    created_at: customer.createdAt.toISOString(),
+    updated_at: customer.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * パスパラメータからIDを取得・検証
+ */
+function parseCustomerId(params: {
+  id: string;
+}):
+  | { success: true; id: number }
+  | { success: false; error: ReturnType<typeof validationErrorResponse> } {
+  const result = customerIdSchema.safeParse({ id: params.id });
+  if (!result.success) {
+    const details: ErrorDetail[] = result.error.issues.map((issue) => ({
+      field: issue.path.join("."),
+      message: issue.message,
+    }));
+    return {
+      success: false,
+      error: validationErrorResponse(details, "顧客IDが不正です"),
+    };
+  }
+  return { success: true, id: result.data.id };
+}
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/v1/customers/{id}
+ * 顧客詳細取得
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const resolvedParams = await params;
+    const parseResult = parseCustomerId(resolvedParams);
+    if (!parseResult.success) {
+      return parseResult.error;
+    }
+
+    const customer = await prisma.customer.findUnique({
+      where: { id: parseResult.id },
+    });
+
+    if (!customer) {
+      return notFoundResponse("指定された顧客が見つかりません");
+    }
+
+    return successResponse(toCustomerResponse(customer));
+  } catch (error) {
+    console.error("顧客詳細取得エラー:", error);
+    return internalErrorResponse("顧客情報の取得に失敗しました");
+  }
+}
+
+/**
+ * PUT /api/v1/customers/{id}
+ * 顧客更新
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const resolvedParams = await params;
+    const parseResult = parseCustomerId(resolvedParams);
+    if (!parseResult.success) {
+      return parseResult.error;
+    }
+
+    const customerId = parseResult.id;
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { id: customerId },
+    });
+
+    if (!existingCustomer) {
+      return notFoundResponse("指定された顧客が見つかりません");
+    }
+
+    // リクエストボディのパース
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return validationErrorResponse(
+        [{ message: "リクエストボディのJSONが不正です" }],
+        "リクエスト形式エラー"
+      );
+    }
+
+    // バリデーション
+    const validationResult = updateCustomerSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      const details: ErrorDetail[] = validationResult.error.issues.map(
+        (issue) => ({
+          field: issue.path.join("."),
+          message: issue.message,
+        })
+      );
+      return validationErrorResponse(details);
+    }
+
+    const { customer_name, address, phone, contact_person } =
+      validationResult.data;
+
+    // 顧客名の重複チェック（自分自身を除く）
+    const duplicateCustomer = await prisma.customer.findFirst({
+      where: {
+        customerName: customer_name,
+        id: { not: customerId },
+      },
+    });
+
+    if (duplicateCustomer) {
+      return errorResponse(
+        ErrorCode.DUPLICATE_ENTRY,
+        "この顧客名は既に登録されています"
+      );
+    }
+
+    // 顧客を更新
+    const customer = await prisma.customer.update({
+      where: { id: customerId },
+      data: {
+        customerName: customer_name,
+        address,
+        phone,
+        contactPerson: contact_person,
+      },
+    });
+
+    return successResponse(toCustomerResponse(customer), {
+      message: "顧客情報を更新しました",
+    });
+  } catch (error) {
+    console.error("顧客更新エラー:", error);
+    return internalErrorResponse("顧客情報の更新に失敗しました");
+  }
+}
+
+/**
+ * DELETE /api/v1/customers/{id}
+ * 顧客削除
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const resolvedParams = await params;
+    const parseResult = parseCustomerId(resolvedParams);
+    if (!parseResult.success) {
+      return parseResult.error;
+    }
+
+    const customerId = parseResult.id;
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { id: customerId },
+    });
+
+    if (!existingCustomer) {
+      return notFoundResponse("指定された顧客が見つかりません");
+    }
+
+    // 訪問記録で使用されているか確認
+    const visitRecordCount = await prisma.visitRecord.count({
+      where: { customerId: customerId },
+    });
+
+    if (visitRecordCount > 0) {
+      return errorResponse(
+        ErrorCode.RESOURCE_IN_USE,
+        "この顧客は訪問記録で使用されているため削除できません"
+      );
+    }
+
+    // 顧客を削除
+    await prisma.customer.delete({
+      where: { id: customerId },
+    });
+
+    return successResponse(null, { message: "顧客を削除しました" });
+  } catch (error) {
+    console.error("顧客削除エラー:", error);
+    return internalErrorResponse("顧客の削除に失敗しました");
+  }
+}

--- a/src/app/api/v1/customers/route.ts
+++ b/src/app/api/v1/customers/route.ts
@@ -1,0 +1,200 @@
+/**
+ * 顧客マスタAPI - 一覧取得・新規作成
+ *
+ * GET /api/v1/customers - 顧客一覧取得（ページネーション対応）
+ * POST /api/v1/customers - 顧客新規作成
+ */
+
+import { ErrorCode } from "@/lib/api/errors";
+import {
+  paginatedResponse,
+  createdResponse,
+  errorResponse,
+  validationErrorResponse,
+  internalErrorResponse,
+} from "@/lib/api/response";
+import { prisma } from "@/lib/prisma";
+import {
+  customerListQuerySchema,
+  createCustomerSchema,
+} from "@/lib/validations/customer";
+
+import type { PaginationInfo, ErrorDetail } from "@/lib/api/response";
+import type { Prisma } from "@prisma/client";
+import type { NextRequest } from "next/server";
+
+/**
+ * Prisma CustomerモデルをAPIレスポンス形式に変換
+ */
+interface CustomerResponse {
+  customer_id: number;
+  customer_name: string;
+  address: string | null;
+  phone: string | null;
+  contact_person: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toCustomerResponse(customer: {
+  id: number;
+  customerName: string;
+  address: string | null;
+  phone: string | null;
+  contactPerson: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): CustomerResponse {
+  return {
+    customer_id: customer.id,
+    customer_name: customer.customerName,
+    address: customer.address,
+    phone: customer.phone,
+    contact_person: customer.contactPerson,
+    created_at: customer.createdAt.toISOString(),
+    updated_at: customer.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * GET /api/v1/customers
+ * 顧客一覧取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    // クエリパラメータのパース・バリデーション
+    const queryResult = customerListQuerySchema.safeParse({
+      customer_name: searchParams.get("customer_name") ?? undefined,
+      page: searchParams.get("page") ?? undefined,
+      per_page: searchParams.get("per_page") ?? undefined,
+      sort: searchParams.get("sort") ?? undefined,
+      order: searchParams.get("order") ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      const details: ErrorDetail[] = queryResult.error.issues.map((issue) => ({
+        field: issue.path.join("."),
+        message: issue.message,
+      }));
+      return validationErrorResponse(details, "クエリパラメータが不正です");
+    }
+
+    const { customer_name, page, per_page, sort, order } = queryResult.data;
+
+    // 検索条件の構築
+    const where: Prisma.CustomerWhereInput = {};
+    if (customer_name) {
+      where.customerName = {
+        contains: customer_name,
+        mode: "insensitive",
+      };
+    }
+
+    // ソート条件の構築
+    const orderBy: Prisma.CustomerOrderByWithRelationInput = {};
+    if (sort === "customer_name") {
+      orderBy.customerName = order;
+    } else {
+      orderBy.createdAt = order;
+    }
+
+    // 総件数を取得
+    const total = await prisma.customer.count({ where });
+
+    // ページネーション計算
+    const skip = (page - 1) * per_page;
+    const lastPage = Math.ceil(total / per_page);
+
+    // 顧客データを取得
+    const customers = await prisma.customer.findMany({
+      where,
+      orderBy,
+      skip,
+      take: per_page,
+    });
+
+    // レスポンス形式に変換
+    const items = customers.map(toCustomerResponse);
+
+    // ページネーション情報
+    const pagination: PaginationInfo = {
+      total,
+      per_page,
+      current_page: page,
+      last_page: lastPage,
+      from: total > 0 ? skip + 1 : 0,
+      to: Math.min(skip + per_page, total),
+    };
+
+    return paginatedResponse(items, pagination);
+  } catch (error) {
+    console.error("顧客一覧取得エラー:", error);
+    return internalErrorResponse("顧客一覧の取得に失敗しました");
+  }
+}
+
+/**
+ * POST /api/v1/customers
+ * 顧客新規作成
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // リクエストボディのパース
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return validationErrorResponse(
+        [{ message: "リクエストボディのJSONが不正です" }],
+        "リクエスト形式エラー"
+      );
+    }
+
+    // バリデーション
+    const validationResult = createCustomerSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      const details: ErrorDetail[] = validationResult.error.issues.map(
+        (issue) => ({
+          field: issue.path.join("."),
+          message: issue.message,
+        })
+      );
+      return validationErrorResponse(details);
+    }
+
+    const { customer_name, address, phone, contact_person } =
+      validationResult.data;
+
+    // 顧客名の重複チェック
+    const existingCustomer = await prisma.customer.findFirst({
+      where: {
+        customerName: customer_name,
+      },
+    });
+
+    if (existingCustomer) {
+      return errorResponse(
+        ErrorCode.DUPLICATE_ENTRY,
+        "この顧客名は既に登録されています"
+      );
+    }
+
+    // 顧客を作成
+    const customer = await prisma.customer.create({
+      data: {
+        customerName: customer_name,
+        address,
+        phone,
+        contactPerson: contact_person,
+      },
+    });
+
+    return createdResponse(toCustomerResponse(customer), "顧客を作成しました");
+  } catch (error) {
+    console.error("顧客作成エラー:", error);
+    return internalErrorResponse("顧客の作成に失敗しました");
+  }
+}

--- a/src/lib/validations/customer.test.ts
+++ b/src/lib/validations/customer.test.ts
@@ -1,0 +1,461 @@
+/**
+ * 顧客マスタバリデーションスキーマのテスト
+ */
+
+import {
+  createCustomerSchema,
+  updateCustomerSchema,
+  customerListQuerySchema,
+  customerIdSchema,
+} from "./customer";
+
+describe("createCustomerSchema", () => {
+  describe("customer_name", () => {
+    it("有効な顧客名を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.customer_name).toBe("株式会社ABC");
+      }
+    });
+
+    it("顧客名が必須", () => {
+      const result = createCustomerSchema.safeParse({});
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path[0]).toBe("customer_name");
+      }
+    });
+
+    it("空の顧客名を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("100文字以内の顧客名を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "あ".repeat(100),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("101文字以上の顧客名を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "あ".repeat(101),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("address", () => {
+    it("有効な住所を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        address: "東京都港区芝1-1-1",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.address).toBe("東京都港区芝1-1-1");
+      }
+    });
+
+    it("住所はオプション", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.address).toBeNull();
+      }
+    });
+
+    it("200文字以内の住所を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        address: "あ".repeat(200),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("201文字以上の住所を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        address: "あ".repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("phone", () => {
+    it("固定電話番号を受け入れる（ハイフンあり）", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "03-1234-5678",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("固定電話番号を受け入れる（ハイフンなし）", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "0312345678",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("携帯電話番号を受け入れる（ハイフンあり）", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "090-1234-5678",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("携帯電話番号を受け入れる（ハイフンなし）", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "09012345678",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("電話番号はオプション", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.phone).toBeNull();
+      }
+    });
+
+    it("不正な電話番号を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "invalid-phone",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("国際電話番号形式を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        phone: "+81-3-1234-5678",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("contact_person", () => {
+    it("有効な担当者名を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        contact_person: "山田太郎",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.contact_person).toBe("山田太郎");
+      }
+    });
+
+    it("担当者名はオプション", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.contact_person).toBeNull();
+      }
+    });
+
+    it("50文字以内の担当者名を受け入れる", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        contact_person: "あ".repeat(50),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("51文字以上の担当者名を拒否する", () => {
+      const result = createCustomerSchema.safeParse({
+        customer_name: "株式会社ABC",
+        contact_person: "あ".repeat(51),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it("全フィールドを含む有効なデータを受け入れる", () => {
+    const result = createCustomerSchema.safeParse({
+      customer_name: "株式会社ABC",
+      address: "東京都港区芝1-1-1",
+      phone: "03-1234-5678",
+      contact_person: "山田太郎",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        customer_name: "株式会社ABC",
+        address: "東京都港区芝1-1-1",
+        phone: "03-1234-5678",
+        contact_person: "山田太郎",
+      });
+    }
+  });
+});
+
+describe("updateCustomerSchema", () => {
+  it("createCustomerSchemaと同じ検証ルールを持つ", () => {
+    const validData = {
+      customer_name: "株式会社ABC",
+      address: "東京都港区芝1-1-1",
+      phone: "03-1234-5678",
+      contact_person: "山田太郎",
+    };
+
+    const createResult = createCustomerSchema.safeParse(validData);
+    const updateResult = updateCustomerSchema.safeParse(validData);
+
+    expect(createResult.success).toBe(true);
+    expect(updateResult.success).toBe(true);
+    if (createResult.success && updateResult.success) {
+      expect(createResult.data).toEqual(updateResult.data);
+    }
+  });
+});
+
+describe("customerListQuerySchema", () => {
+  describe("customer_name", () => {
+    it("検索用顧客名を受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        customer_name: "株式会社",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.customer_name).toBe("株式会社");
+      }
+    });
+
+    it("customer_nameはオプション", () => {
+      const result = customerListQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.customer_name).toBeUndefined();
+      }
+    });
+  });
+
+  describe("page", () => {
+    it("有効なページ番号を受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        page: 5,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.page).toBe(5);
+      }
+    });
+
+    it("文字列のページ番号を数値に変換する", () => {
+      const result = customerListQuerySchema.safeParse({
+        page: "3",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.page).toBe(3);
+      }
+    });
+
+    it("デフォルト値は1", () => {
+      const result = customerListQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.page).toBe(1);
+      }
+    });
+
+    it("0を拒否する", () => {
+      const result = customerListQuerySchema.safeParse({
+        page: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("負の値を拒否する", () => {
+      const result = customerListQuerySchema.safeParse({
+        page: -1,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("per_page", () => {
+    it("有効な表示件数を受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        per_page: 50,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.per_page).toBe(50);
+      }
+    });
+
+    it("デフォルト値は20", () => {
+      const result = customerListQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.per_page).toBe(20);
+      }
+    });
+
+    it("100を受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        per_page: 100,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("101を拒否する", () => {
+      const result = customerListQuerySchema.safeParse({
+        per_page: 101,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("sort", () => {
+    it("customer_nameを受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        sort: "customer_name",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.sort).toBe("customer_name");
+      }
+    });
+
+    it("created_atを受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        sort: "created_at",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.sort).toBe("created_at");
+      }
+    });
+
+    it("デフォルト値はcreated_at", () => {
+      const result = customerListQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.sort).toBe("created_at");
+      }
+    });
+
+    it("無効なソート項目を拒否する", () => {
+      const result = customerListQuerySchema.safeParse({
+        sort: "invalid",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("order", () => {
+    it("ascを受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        order: "asc",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.order).toBe("asc");
+      }
+    });
+
+    it("descを受け入れる", () => {
+      const result = customerListQuerySchema.safeParse({
+        order: "desc",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.order).toBe("desc");
+      }
+    });
+
+    it("デフォルト値はdesc", () => {
+      const result = customerListQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.order).toBe("desc");
+      }
+    });
+
+    it("無効なソート順を拒否する", () => {
+      const result = customerListQuerySchema.safeParse({
+        order: "ascending",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it("全クエリパラメータを含む有効なデータを受け入れる", () => {
+    const result = customerListQuerySchema.safeParse({
+      customer_name: "株式会社",
+      page: 2,
+      per_page: 30,
+      sort: "customer_name",
+      order: "asc",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        customer_name: "株式会社",
+        page: 2,
+        per_page: 30,
+        sort: "customer_name",
+        order: "asc",
+      });
+    }
+  });
+});
+
+describe("customerIdSchema", () => {
+  it("有効な正の整数IDを受け入れる", () => {
+    const result = customerIdSchema.safeParse({ id: 1 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(1);
+    }
+  });
+
+  it("文字列のIDを数値に変換する", () => {
+    const result = customerIdSchema.safeParse({ id: "42" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(42);
+    }
+  });
+
+  it("0を拒否する", () => {
+    const result = customerIdSchema.safeParse({ id: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("負の値を拒否する", () => {
+    const result = customerIdSchema.safeParse({ id: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("小数を整数に変換する", () => {
+    const result = customerIdSchema.safeParse({ id: 3.7 });
+    expect(result.success).toBe(false);
+  });
+
+  it("文字列（非数値）を拒否する", () => {
+    const result = customerIdSchema.safeParse({ id: "abc" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/validations/customer.ts
+++ b/src/lib/validations/customer.ts
@@ -1,0 +1,107 @@
+/**
+ * 顧客マスタのバリデーションスキーマ
+ */
+
+import { z } from "zod";
+
+/**
+ * 日本の電話番号形式の正規表現
+ * - 固定電話: 03-1234-5678, 06-9876-5432 など
+ * - 携帯電話: 090-1234-5678, 080-9876-5432 など
+ * - ハイフンあり・なしの両方に対応
+ */
+const PHONE_REGEX = /^(0[0-9]{1,4}-?[0-9]{1,4}-?[0-9]{4}|0[0-9]{9,10})$/;
+
+/**
+ * 顧客作成リクエストのスキーマ
+ */
+export const createCustomerSchema = z.object({
+  customer_name: z
+    .string({
+      required_error: "顧客名は必須です",
+      invalid_type_error: "顧客名は文字列である必要があります",
+    })
+    .min(1, "顧客名は必須です")
+    .max(100, "顧客名は100文字以内で入力してください"),
+
+  address: z
+    .string()
+    .max(200, "住所は200文字以内で入力してください")
+    .nullish()
+    .transform((val) => val ?? null),
+
+  phone: z
+    .string()
+    .refine((val) => !val || PHONE_REGEX.test(val), {
+      message:
+        "電話番号の形式が正しくありません（例: 03-1234-5678, 090-1234-5678）",
+    })
+    .nullish()
+    .transform((val) => val ?? null),
+
+  contact_person: z
+    .string()
+    .max(50, "担当者名は50文字以内で入力してください")
+    .nullish()
+    .transform((val) => val ?? null),
+});
+
+/**
+ * 顧客更新リクエストのスキーマ
+ */
+export const updateCustomerSchema = z.object({
+  customer_name: z
+    .string({
+      required_error: "顧客名は必須です",
+      invalid_type_error: "顧客名は文字列である必要があります",
+    })
+    .min(1, "顧客名は必須です")
+    .max(100, "顧客名は100文字以内で入力してください"),
+
+  address: z
+    .string()
+    .max(200, "住所は200文字以内で入力してください")
+    .nullish()
+    .transform((val) => val ?? null),
+
+  phone: z
+    .string()
+    .refine((val) => !val || PHONE_REGEX.test(val), {
+      message:
+        "電話番号の形式が正しくありません（例: 03-1234-5678, 090-1234-5678）",
+    })
+    .nullish()
+    .transform((val) => val ?? null),
+
+  contact_person: z
+    .string()
+    .max(50, "担当者名は50文字以内で入力してください")
+    .nullish()
+    .transform((val) => val ?? null),
+});
+
+/**
+ * 顧客一覧取得クエリパラメータのスキーマ
+ */
+export const customerListQuerySchema = z.object({
+  customer_name: z.string().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  per_page: z.coerce.number().int().positive().max(100).default(20),
+  sort: z.enum(["customer_name", "created_at"]).default("created_at"),
+  order: z.enum(["asc", "desc"]).default("desc"),
+});
+
+/**
+ * 顧客IDパラメータのスキーマ
+ */
+export const customerIdSchema = z.object({
+  id: z.coerce.number().int().positive("顧客IDは正の整数である必要があります"),
+});
+
+/**
+ * 型定義のエクスポート
+ */
+export type CreateCustomerInput = z.infer<typeof createCustomerSchema>;
+export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>;
+export type CustomerListQuery = z.infer<typeof customerListQuerySchema>;
+export type CustomerIdParams = z.infer<typeof customerIdSchema>;


### PR DESCRIPTION
## Summary
- 顧客マスタのCRUD API（全5エンドポイント）を実装
- Zodバリデーションスキーマとユニットテスト（48件）を追加
- 訪問記録で使用中の顧客削除防止、顧客名重複チェックを実装

## 実装したエンドポイント
| メソッド | パス | 概要 |
|----------|------|------|
| GET | /api/v1/customers | 一覧取得（ページネーション、検索、ソート対応） |
| GET | /api/v1/customers/{id} | 詳細取得 |
| POST | /api/v1/customers | 新規作成 |
| PUT | /api/v1/customers/{id} | 更新 |
| DELETE | /api/v1/customers/{id} | 削除 |

## 作成したファイル
- `src/app/api/v1/customers/route.ts` - 一覧取得・新規作成API
- `src/app/api/v1/customers/[id]/route.ts` - 詳細取得・更新・削除API
- `src/lib/validations/customer.ts` - Zodバリデーションスキーマ
- `src/lib/validations/customer.test.ts` - バリデーションテスト（48件）

## Test plan
- [x] `npm run type-check` が成功する
- [x] `npm run lint` が成功する
- [x] `npm run test:run` で全244件のテストがパスする

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)