### PR TITLE
feat: Issue #8 営業担当者マスタ画面の実装

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,12 +1,12 @@
 module.exports = {
   // TypeScript/JavaScript ファイル
-  "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
+  "**/*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
 
   // スタイルファイル
-  "*.{css,scss}": ["prettier --write"],
+  "**/*.{css,scss}": ["prettier --write"],
 
   // JSON/Markdown ファイル
-  "*.{json,md}": ["prettier --write"],
+  "**/*.{json,md}": ["prettier --write"],
 
   // Prisma スキーマ
   "prisma/schema.prisma": ["npx prisma format"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -3198,6 +3199,38 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/app/sales-persons/[id]/edit/page.tsx
+++ b/src/app/sales-persons/[id]/edit/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import { SalesPersonEditContainer } from "@/features/sales-persons/components/SalesPersonEditContainer";
+
+export const metadata = {
+  title: "営業担当者編集 | 営業日報システム",
+  description: "営業担当者情報を編集します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+interface EditSalesPersonPageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default async function EditSalesPersonPage({
+  params,
+}: EditSalesPersonPageProps) {
+  const { id } = await params;
+  const salesPersonId = parseInt(id, 10);
+
+  if (isNaN(salesPersonId) || salesPersonId <= 0) {
+    notFound();
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-2xl font-bold">営業担当者マスタ 編集</h1>
+        <SalesPersonEditContainer salesPersonId={salesPersonId} />
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/sales-persons/new/page.tsx
+++ b/src/app/sales-persons/new/page.tsx
@@ -1,0 +1,21 @@
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import { SalesPersonForm } from "@/features/sales-persons/components/SalesPersonForm";
+
+export const metadata = {
+  title: "営業担当者登録 | 営業日報システム",
+  description: "新規営業担当者を登録します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+export default function NewSalesPersonPage() {
+  return (
+    <AuthenticatedLayout>
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-2xl font-bold">営業担当者マスタ 登録</h1>
+        <SalesPersonForm />
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/sales-persons/page.tsx
+++ b/src/app/sales-persons/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from "react";
+
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import {
+  SalesPersonsList,
+  SalesPersonsListSkeleton,
+} from "@/features/sales-persons/components";
+
+export const metadata = {
+  title: "営業担当者マスタ | 営業日報システム",
+  description: "営業担当者の一覧を表示します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+export default function SalesPersonsPage() {
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">営業担当者マスタ</h1>
+        <Suspense fallback={<SalesPersonsListSkeleton />}>
+          <SalesPersonsList />
+        </Suspense>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface PaginationProps {
+  currentPage: number;
+  lastPage: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({
+  currentPage,
+  lastPage,
+  total,
+  onPageChange,
+}: PaginationProps) {
+  const hasPrevPage = currentPage > 1;
+  const hasNextPage = currentPage < lastPage;
+
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-muted-foreground">
+        全{total}件中 {currentPage}ページ / {lastPage}ページ
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={!hasPrevPage}
+          aria-label="前のページ"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          前へ
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={!hasNextPage}
+          aria-label="次のページ"
+        >
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/src/features/sales-persons/api.ts
+++ b/src/features/sales-persons/api.ts
@@ -1,0 +1,186 @@
+/**
+ * 営業担当者マスタAPI関数
+ */
+
+import { SALES_PERSONS_API_BASE } from "./constants";
+
+import type {
+  ApiErrorResponse,
+  SalesPersonDeleteResponse,
+  SalesPersonDetailResponse,
+  SalesPersonMutationResponse,
+  SalesPersonsListResponse,
+  SearchParams,
+} from "./types";
+
+/**
+ * 営業担当者一覧を取得
+ */
+export async function fetchSalesPersons(
+  params: SearchParams = {}
+): Promise<SalesPersonsListResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params.name) {
+    searchParams.set("name", params.name);
+  }
+  if (params.department) {
+    searchParams.set("department", params.department);
+  }
+  if (params.page) {
+    searchParams.set("page", params.page.toString());
+  }
+  if (params.per_page) {
+    searchParams.set("per_page", params.per_page.toString());
+  }
+
+  const queryString = searchParams.toString();
+  const url = queryString
+    ? `${SALES_PERSONS_API_BASE}?${queryString}`
+    : SALES_PERSONS_API_BASE;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "営業担当者一覧の取得に失敗しました"
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * 上長一覧を取得（is_manager=trueのユーザー）
+ */
+export async function fetchManagers(): Promise<SalesPersonsListResponse> {
+  const response = await fetch(
+    `${SALES_PERSONS_API_BASE}?is_manager=true&per_page=100`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "上長一覧の取得に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * 営業担当者詳細を取得
+ */
+export async function fetchSalesPerson(
+  id: number
+): Promise<SalesPersonDetailResponse> {
+  const response = await fetch(`${SALES_PERSONS_API_BASE}/${id}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "営業担当者の取得に失敗しました"
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * 営業担当者を作成
+ */
+export async function createSalesPerson(data: {
+  name: string;
+  email: string;
+  password: string;
+  department: string;
+  manager_id: number | null;
+  is_manager: boolean;
+}): Promise<SalesPersonMutationResponse> {
+  const response = await fetch(SALES_PERSONS_API_BASE, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "営業担当者の作成に失敗しました"
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * 営業担当者を更新
+ */
+export async function updateSalesPerson(
+  id: number,
+  data: {
+    name: string;
+    email: string;
+    password?: string;
+    department: string;
+    manager_id: number | null;
+    is_manager: boolean;
+  }
+): Promise<SalesPersonMutationResponse> {
+  const response = await fetch(`${SALES_PERSONS_API_BASE}/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "営業担当者の更新に失敗しました"
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * 営業担当者を削除
+ */
+export async function deleteSalesPerson(
+  id: number
+): Promise<SalesPersonDeleteResponse> {
+  const response = await fetch(`${SALES_PERSONS_API_BASE}/${id}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "営業担当者の削除に失敗しました"
+    );
+  }
+
+  return response.json();
+}

--- a/src/features/sales-persons/components/SalesPersonEditContainer.tsx
+++ b/src/features/sales-persons/components/SalesPersonEditContainer.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { fetchSalesPerson } from "../api";
+import { SalesPersonEditForm } from "./SalesPersonEditForm";
+
+import type { SalesPersonResponse } from "../types";
+
+interface SalesPersonEditContainerProps {
+  salesPersonId: number;
+}
+
+export function SalesPersonEditContainer({
+  salesPersonId,
+}: SalesPersonEditContainerProps) {
+  const router = useRouter();
+  const [salesPerson, setSalesPerson] = useState<SalesPersonResponse | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadSalesPerson = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetchSalesPerson(salesPersonId);
+        setSalesPerson(response.data);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "営業担当者の取得に失敗しました"
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadSalesPerson();
+  }, [salesPersonId]);
+
+  if (isLoading) {
+    return <SalesPersonEditSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+        <Button variant="outline" onClick={() => router.push("/sales-persons")}>
+          一覧に戻る
+        </Button>
+      </div>
+    );
+  }
+
+  if (!salesPerson) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>営業担当者が見つかりませんでした</AlertDescription>
+        </Alert>
+        <Button variant="outline" onClick={() => router.push("/sales-persons")}>
+          一覧に戻る
+        </Button>
+      </div>
+    );
+  }
+
+  return <SalesPersonEditForm salesPerson={salesPerson} />;
+}
+
+function SalesPersonEditSkeleton() {
+  return (
+    <div className="rounded-xl border bg-card p-6 shadow">
+      <Skeleton className="mb-6 h-6 w-48" />
+      <div className="space-y-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        ))}
+        <div className="flex justify-between">
+          <Skeleton className="h-9 w-20" />
+          <div className="flex gap-4">
+            <Skeleton className="h-9 w-24" />
+            <Skeleton className="h-9 w-20" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonEditForm.tsx
+++ b/src/features/sales-persons/components/SalesPersonEditForm.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle, Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { deleteSalesPerson, fetchManagers, updateSalesPerson } from "../api";
+import { DEPARTMENTS, isManagerToRoleValue, ROLES } from "../constants";
+import {
+  convertFormToApiRequest,
+  updateSalesPersonFormSchema,
+} from "../schemas";
+
+import type { UpdateSalesPersonFormValues } from "../schemas";
+import type { SalesPersonListItem, SalesPersonResponse } from "../types";
+
+interface SalesPersonEditFormProps {
+  salesPerson: SalesPersonResponse;
+}
+
+export function SalesPersonEditForm({ salesPerson }: SalesPersonEditFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [managers, setManagers] = useState<SalesPersonListItem[]>([]);
+  const [isLoadingManagers, setIsLoadingManagers] = useState(true);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  // 上長一覧を取得（自分自身を除外）
+  useEffect(() => {
+    const loadManagers = async () => {
+      try {
+        const response = await fetchManagers();
+        const filteredManagers = response.data.items.filter(
+          (m) => m.sales_person_id !== salesPerson.sales_person_id
+        );
+        setManagers(filteredManagers);
+      } catch (err) {
+        console.error("上長一覧の取得に失敗しました:", err);
+      } finally {
+        setIsLoadingManagers(false);
+      }
+    };
+
+    loadManagers();
+  }, [salesPerson.sales_person_id]);
+
+  const form = useForm<UpdateSalesPersonFormValues>({
+    resolver: zodResolver(updateSalesPersonFormSchema),
+    defaultValues: {
+      name: salesPerson.name,
+      email: salesPerson.email,
+      password: "",
+      department: salesPerson.department,
+      manager_id: salesPerson.manager_id?.toString() || "",
+      role: isManagerToRoleValue(salesPerson.is_manager),
+    },
+  });
+
+  const onSubmit = async (data: UpdateSalesPersonFormValues) => {
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const apiData = convertFormToApiRequest(data, true);
+        await updateSalesPerson(salesPerson.sales_person_id, apiData);
+        router.push("/sales-persons");
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "更新に失敗しました");
+      }
+    });
+  };
+
+  const handleDelete = async () => {
+    setDeleteError(null);
+    setIsDeleting(true);
+
+    try {
+      await deleteSalesPerson(salesPerson.sales_person_id);
+      setIsDeleteDialogOpen(false);
+      router.push("/sales-persons");
+      router.refresh();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "削除に失敗しました");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    router.push("/sales-persons");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>営業担当者マスタ 編集</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    氏名 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="山田太郎"
+                      maxLength={50}
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    メールアドレス <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="example@example.com"
+                      autoComplete="email"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>パスワード</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="変更する場合のみ入力"
+                      autoComplete="new-password"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    空欄の場合、パスワードは変更されません
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="department"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    部署 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="部署を選択してください" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {DEPARTMENTS.map((dept) => (
+                        <SelectItem key={dept.value} value={dept.value}>
+                          {dept.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="manager_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>上長</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending || isLoadingManagers}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={
+                            isLoadingManagers
+                              ? "読み込み中..."
+                              : "上長を選択してください"
+                          }
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="">なし</SelectItem>
+                      {managers.map((manager) => (
+                        <SelectItem
+                          key={manager.sales_person_id}
+                          value={manager.sales_person_id.toString()}
+                        >
+                          {manager.name}（{manager.department}）
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    上長権限を持つユーザーから選択できます
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    権限 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="flex gap-6"
+                      disabled={isPending}
+                    >
+                      {ROLES.map((role) => (
+                        <div
+                          key={role.value}
+                          className="flex items-center space-x-2"
+                        >
+                          <RadioGroupItem value={role.value} id={role.value} />
+                          <Label
+                            htmlFor={role.value}
+                            className="cursor-pointer"
+                          >
+                            {role.label}
+                          </Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-between">
+              <Dialog
+                open={isDeleteDialogOpen}
+                onOpenChange={setIsDeleteDialogOpen}
+              >
+                <DialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={isPending}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    削除
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>営業担当者の削除</DialogTitle>
+                    <DialogDescription>
+                      「{salesPerson.name}」を削除してもよろしいですか？
+                      <br />
+                      この操作は取り消すことができません。
+                    </DialogDescription>
+                  </DialogHeader>
+                  {deleteError && (
+                    <Alert variant="destructive">
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>{deleteError}</AlertDescription>
+                    </Alert>
+                  )}
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isDeleting}
+                      >
+                        キャンセル
+                      </Button>
+                    </DialogClose>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      onClick={handleDelete}
+                      disabled={isDeleting}
+                    >
+                      {isDeleting && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      )}
+                      削除する
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+
+              <div className="flex gap-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCancel}
+                  disabled={isPending}
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isPending}>
+                  {isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  保存
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonForm.test.tsx
+++ b/src/features/sales-persons/components/SalesPersonForm.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen, mockAdminUser, waitFor } from "@/test/test-utils";
+
+import { SalesPersonForm } from "./SalesPersonForm";
+
+import type { SalesPersonResponse, SalesPersonListItem } from "../types";
+
+// next/navigation のモック
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/sales-persons/new",
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+// API モック
+const mockFetchManagers = vi.fn();
+vi.mock("../api", () => ({
+  fetchManagers: () => mockFetchManagers(),
+  createSalesPerson: vi.fn().mockResolvedValue({ success: true }),
+  updateSalesPerson: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+const mockManagers: SalesPersonListItem[] = [
+  {
+    sales_person_id: 10,
+    name: "管理者一郎",
+    email: "admin@example.com",
+    department: "営業1課",
+    manager_id: null,
+    manager_name: null,
+    is_manager: true,
+  },
+];
+
+describe("SalesPersonForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchManagers.mockResolvedValue({
+      success: true,
+      data: { items: mockManagers },
+    });
+  });
+
+  describe("rendering - create mode", () => {
+    it("should render all form fields", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText(/メールアドレス/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/パスワード/)).toBeInTheDocument();
+      expect(screen.getByText("部署")).toBeInTheDocument();
+      // "上長" is used both as form label and radio option, so check for at least one
+      expect(screen.getAllByText("上長").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("権限")).toBeInTheDocument();
+    });
+
+    it("should show required indicators", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      // 氏名、メールアドレス、パスワード、部署、権限に * がある
+      const requiredIndicators = screen.getAllByText("*");
+      expect(requiredIndicators.length).toBe(5);
+    });
+
+    it("should show title for create mode", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByText("営業担当者マスタ 登録")).toBeInTheDocument();
+      });
+    });
+
+    it("should show role options", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("一般")).toBeInTheDocument();
+      });
+      // "上長" radio button can be found by its input element
+      expect(screen.getByRole("radio", { name: "上長" })).toBeInTheDocument();
+    });
+
+    it("should show save and cancel buttons", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "保存" })
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("button", { name: "キャンセル" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("rendering - edit mode", () => {
+    const mockSalesPerson: SalesPersonResponse = {
+      sales_person_id: 1,
+      name: "山田太郎",
+      email: "yamada@example.com",
+      department: "営業1課",
+      manager_id: 10,
+      manager_name: "管理者一郎",
+      is_manager: false,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+
+    it("should show title for edit mode", async () => {
+      render(<SalesPersonForm salesPerson={mockSalesPerson} isEdit />, {
+        user: mockAdminUser,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("営業担当者マスタ 編集")).toBeInTheDocument();
+      });
+    });
+
+    it("should populate form with existing data", async () => {
+      render(<SalesPersonForm salesPerson={mockSalesPerson} isEdit />, {
+        user: mockAdminUser,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toHaveValue("山田太郎");
+      });
+      expect(screen.getByLabelText(/メールアドレス/)).toHaveValue(
+        "yamada@example.com"
+      );
+      expect(screen.getByLabelText(/パスワード/)).toHaveValue("");
+    });
+
+    it("should show password description in edit mode", async () => {
+      render(<SalesPersonForm salesPerson={mockSalesPerson} isEdit />, {
+        user: mockAdminUser,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("空欄の場合、パスワードは変更されません")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should not show required indicator for password in edit mode", async () => {
+      render(<SalesPersonForm salesPerson={mockSalesPerson} isEdit />, {
+        user: mockAdminUser,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      // 編集モードでは氏名、メールアドレス、部署、権限に * がある（パスワードは不要）
+      const requiredIndicators = screen.getAllByText("*");
+      expect(requiredIndicators.length).toBe(4);
+    });
+  });
+
+  describe("validation - create mode", () => {
+    it("should show validation errors when submitting empty form", async () => {
+      const { user } = render(<SalesPersonForm />, { user: mockAdminUser });
+
+      // マネージャー読み込み待ち
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "保存" })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      // 空のフォーム送信時にバリデーションエラーが表示される
+      await waitFor(() => {
+        expect(screen.getByText("氏名を入力してください")).toBeInTheDocument();
+      });
+    });
+
+    it("should show email validation error", async () => {
+      const { user } = render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/氏名/), "テスト");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("メールアドレスを入力してください")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should show password validation error", async () => {
+      const { user } = render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/氏名/), "テスト");
+      await user.type(
+        screen.getByLabelText(/メールアドレス/),
+        "test@example.com"
+      );
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("パスワードは8文字以上で入力してください")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should show department validation error", async () => {
+      const { user } = render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/氏名/), "テスト");
+      await user.type(
+        screen.getByLabelText(/メールアドレス/),
+        "test@example.com"
+      );
+      await user.type(screen.getByLabelText(/パスワード/), "12345678");
+      await user.click(screen.getByRole("button", { name: "保存" }));
+
+      // エラーメッセージを特定のクラスで検索
+      await waitFor(() => {
+        const errorMessages = screen.getAllByText("部署を選択してください");
+        const errorElement = errorMessages.find((el) =>
+          el.classList.contains("text-destructive")
+        );
+        expect(errorElement).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("managers loading", () => {
+    it("should load managers on mount", async () => {
+      render(<SalesPersonForm />, { user: mockAdminUser });
+
+      await waitFor(() => {
+        expect(mockFetchManagers).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/features/sales-persons/components/SalesPersonForm.tsx
+++ b/src/features/sales-persons/components/SalesPersonForm.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { createSalesPerson, fetchManagers, updateSalesPerson } from "../api";
+import { DEPARTMENTS, isManagerToRoleValue, ROLES } from "../constants";
+import {
+  convertFormToApiRequest,
+  createSalesPersonFormSchema,
+  updateSalesPersonFormSchema,
+} from "../schemas";
+
+import type {
+  CreateSalesPersonFormValues,
+  UpdateSalesPersonFormValues,
+} from "../schemas";
+import type { SalesPersonListItem, SalesPersonResponse } from "../types";
+
+interface SalesPersonFormProps {
+  /** 編集モードの場合は既存データを渡す */
+  salesPerson?: SalesPersonResponse;
+  /** 編集モードかどうか */
+  isEdit?: boolean;
+}
+
+export function SalesPersonForm({
+  salesPerson,
+  isEdit = false,
+}: SalesPersonFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [managers, setManagers] = useState<SalesPersonListItem[]>([]);
+  const [isLoadingManagers, setIsLoadingManagers] = useState(true);
+
+  // 上長一覧を取得
+  useEffect(() => {
+    const loadManagers = async () => {
+      try {
+        const response = await fetchManagers();
+        // 編集モードの場合、自分自身を除外
+        const filteredManagers = salesPerson
+          ? response.data.items.filter(
+              (m) => m.sales_person_id !== salesPerson.sales_person_id
+            )
+          : response.data.items;
+        setManagers(filteredManagers);
+      } catch (err) {
+        console.error("上長一覧の取得に失敗しました:", err);
+      } finally {
+        setIsLoadingManagers(false);
+      }
+    };
+
+    loadManagers();
+  }, [salesPerson]);
+
+  // 登録用フォーム
+  const createForm = useForm<CreateSalesPersonFormValues>({
+    resolver: zodResolver(createSalesPersonFormSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      password: "",
+      department: "",
+      manager_id: "_none",
+      role: "general",
+    },
+  });
+
+  // 編集用フォーム
+  const updateForm = useForm<UpdateSalesPersonFormValues>({
+    resolver: zodResolver(updateSalesPersonFormSchema),
+    defaultValues: salesPerson
+      ? {
+          name: salesPerson.name,
+          email: salesPerson.email,
+          password: "",
+          department: salesPerson.department,
+          manager_id: salesPerson.manager_id?.toString() || "_none",
+          role: isManagerToRoleValue(salesPerson.is_manager),
+        }
+      : {
+          name: "",
+          email: "",
+          password: "",
+          department: "",
+          manager_id: "_none",
+          role: "general",
+        },
+  });
+
+  const form = isEdit ? updateForm : createForm;
+
+  const onSubmit = async (
+    data: CreateSalesPersonFormValues | UpdateSalesPersonFormValues
+  ) => {
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const apiData = convertFormToApiRequest(data, isEdit);
+
+        if (isEdit && salesPerson) {
+          await updateSalesPerson(salesPerson.sales_person_id, apiData);
+        } else {
+          await createSalesPerson(apiData as Required<typeof apiData>);
+        }
+
+        router.push("/sales-persons");
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "保存に失敗しました");
+      }
+    });
+  };
+
+  const handleCancel = () => {
+    router.push("/sales-persons");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {isEdit ? "営業担当者マスタ 編集" : "営業担当者マスタ 登録"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    氏名 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="山田太郎"
+                      maxLength={50}
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    メールアドレス <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="example@example.com"
+                      autoComplete="email"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    パスワード{" "}
+                    {!isEdit && <span className="text-destructive">*</span>}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder={
+                        isEdit
+                          ? "変更する場合のみ入力"
+                          : "8文字以上で入力してください"
+                      }
+                      autoComplete="new-password"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  {isEdit && (
+                    <FormDescription>
+                      空欄の場合、パスワードは変更されません
+                    </FormDescription>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="department"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    部署 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="部署を選択してください" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {DEPARTMENTS.map((dept) => (
+                        <SelectItem key={dept.value} value={dept.value}>
+                          {dept.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="manager_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>上長</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending || isLoadingManagers}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={
+                            isLoadingManagers
+                              ? "読み込み中..."
+                              : "上長を選択してください"
+                          }
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="_none">なし</SelectItem>
+                      {managers.map((manager) => (
+                        <SelectItem
+                          key={manager.sales_person_id}
+                          value={manager.sales_person_id.toString()}
+                        >
+                          {manager.name}（{manager.department}）
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    上長権限を持つユーザーから選択できます
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    権限 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="flex gap-6"
+                      disabled={isPending}
+                    >
+                      {ROLES.map((role) => (
+                        <div
+                          key={role.value}
+                          className="flex items-center space-x-2"
+                        >
+                          <RadioGroupItem value={role.value} id={role.value} />
+                          <Label
+                            htmlFor={role.value}
+                            className="cursor-pointer"
+                          >
+                            {role.label}
+                          </Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isPending}
+              >
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                保存
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonsList.tsx
+++ b/src/features/sales-persons/components/SalesPersonsList.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { AlertCircle, Plus } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { Pagination } from "@/components/common/Pagination";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+import { fetchSalesPersons } from "../api";
+import { DEFAULT_PER_PAGE } from "../constants";
+import { SalesPersonsListSkeleton } from "./SalesPersonsListSkeleton";
+import { SalesPersonsSearchForm } from "./SalesPersonsSearchForm";
+import { SalesPersonsTable } from "./SalesPersonsTable";
+
+import type { SearchFormValues } from "../schemas";
+import type {
+  Pagination as PaginationType,
+  SalesPersonListItem,
+} from "../types";
+
+export function SalesPersonsList() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [salesPersons, setSalesPersons] = useState<SalesPersonListItem[]>([]);
+  const [pagination, setPagination] = useState<PaginationType | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // URLパラメータから初期値を取得
+  const initialName = searchParams.get("name") || "";
+  const initialDepartment = searchParams.get("department") || "";
+  const initialPage = parseInt(searchParams.get("page") || "1", 10);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const name = searchParams.get("name");
+      const department = searchParams.get("department");
+      const page = parseInt(searchParams.get("page") || "1", 10);
+
+      const response = await fetchSalesPersons({
+        ...(name ? { name } : {}),
+        ...(department ? { department } : {}),
+        page,
+        per_page: DEFAULT_PER_PAGE,
+      });
+
+      setSalesPersons(response.data.items);
+      setPagination(response.data.pagination);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "データの取得に失敗しました"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const updateSearchParams = useCallback(
+    (params: Record<string, string | undefined>) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+
+      Object.entries(params).forEach(([key, value]) => {
+        if (value) {
+          newParams.set(key, value);
+        } else {
+          newParams.delete(key);
+        }
+      });
+
+      router.push(`/sales-persons?${newParams.toString()}`);
+    },
+    [router, searchParams]
+  );
+
+  const handleSearch = useCallback(
+    (values: SearchFormValues) => {
+      // "_all" は「全て」を表す特殊値なので、空文字列として扱う
+      const department =
+        values.department && values.department !== "_all"
+          ? values.department
+          : undefined;
+      updateSearchParams({
+        name: values.name || undefined,
+        department,
+        page: "1", // 検索時は1ページ目に戻る
+      });
+    },
+    [updateSearchParams]
+  );
+
+  const handleClear = useCallback(() => {
+    router.push("/sales-persons");
+  }, [router]);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      updateSearchParams({ page: page.toString() });
+    },
+    [updateSearchParams]
+  );
+
+  if (isLoading) {
+    return <SalesPersonsListSkeleton />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <SalesPersonsSearchForm
+        defaultValues={{
+          name: initialName,
+          department: initialDepartment,
+        }}
+        onSearch={handleSearch}
+        onClear={handleClear}
+        isLoading={isLoading}
+      />
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          検索結果: {pagination?.total || 0}件
+        </p>
+        <Button asChild>
+          <Link href="/sales-persons/new">
+            <Plus className="mr-2 h-4 w-4" />
+            新規登録
+          </Link>
+        </Button>
+      </div>
+
+      <SalesPersonsTable
+        salesPersons={salesPersons}
+        startIndex={(initialPage - 1) * DEFAULT_PER_PAGE}
+      />
+
+      {pagination && pagination.last_page > 1 && (
+        <Pagination
+          currentPage={pagination.current_page}
+          lastPage={pagination.last_page}
+          total={pagination.total}
+          onPageChange={handlePageChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonsListSkeleton.tsx
+++ b/src/features/sales-persons/components/SalesPersonsListSkeleton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SalesPersonsListSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* 検索フォームスケルトン */}
+      <div className="rounded-xl border p-6">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-9 w-20" />
+        </div>
+      </div>
+
+      {/* テーブルスケルトン */}
+      <div className="rounded-md border">
+        <div className="p-4">
+          <div className="flex h-10 items-center border-b">
+            <Skeleton className="h-4 w-8 mr-8" />
+            <Skeleton className="h-4 w-24 mr-8" />
+            <Skeleton className="h-4 w-20 mr-8" />
+            <Skeleton className="h-4 w-24 mr-8" />
+            <Skeleton className="h-4 w-16 mr-8" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex h-14 items-center border-b last:border-b-0"
+            >
+              <Skeleton className="h-4 w-6 mr-10" />
+              <Skeleton className="h-4 w-20 mr-10" />
+              <Skeleton className="h-4 w-16 mr-10" />
+              <Skeleton className="h-4 w-20 mr-10" />
+              <Skeleton className="h-5 w-12 mr-10" />
+              <Skeleton className="h-8 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ページネーションスケルトン */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-40" />
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-20" />
+          <Skeleton className="h-9 w-20" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonsSearchForm.test.tsx
+++ b/src/features/sales-persons/components/SalesPersonsSearchForm.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen, mockAdminUser, waitFor } from "@/test/test-utils";
+
+import { SalesPersonsSearchForm } from "./SalesPersonsSearchForm";
+
+describe("SalesPersonsSearchForm", () => {
+  const defaultProps = {
+    onSearch: vi.fn(),
+    onClear: vi.fn(),
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render search form fields", () => {
+      render(<SalesPersonsSearchForm {...defaultProps} />, {
+        user: mockAdminUser,
+      });
+
+      expect(screen.getByLabelText("氏名")).toBeInTheDocument();
+      expect(screen.getByLabelText("部署")).toBeInTheDocument();
+    });
+
+    it("should render search and clear buttons", () => {
+      render(<SalesPersonsSearchForm {...defaultProps} />, {
+        user: mockAdminUser,
+      });
+
+      expect(screen.getByRole("button", { name: /検索/ })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /クリア/ })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("default values", () => {
+    it("should populate form with default values", () => {
+      render(
+        <SalesPersonsSearchForm
+          {...defaultProps}
+          defaultValues={{ name: "山田", department: "営業1課" }}
+        />,
+        { user: mockAdminUser }
+      );
+
+      expect(screen.getByLabelText("氏名")).toHaveValue("山田");
+    });
+  });
+
+  describe("search submission", () => {
+    it("should call onSearch with form values when submitted", async () => {
+      const onSearch = vi.fn();
+      const { user } = render(
+        <SalesPersonsSearchForm {...defaultProps} onSearch={onSearch} />,
+        { user: mockAdminUser }
+      );
+
+      await user.type(screen.getByLabelText("氏名"), "山田");
+      await user.click(screen.getByRole("button", { name: /検索/ }));
+
+      await waitFor(() => {
+        expect(onSearch).toHaveBeenCalled();
+        expect(onSearch.mock.calls[0]?.[0]).toEqual({
+          name: "山田",
+          department: "_all",
+        });
+      });
+    });
+  });
+
+  describe("clear functionality", () => {
+    it("should call onClear when clear button is clicked", async () => {
+      const onClear = vi.fn();
+      const { user } = render(
+        <SalesPersonsSearchForm
+          {...defaultProps}
+          onClear={onClear}
+          defaultValues={{ name: "山田", department: "営業1課" }}
+        />,
+        { user: mockAdminUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: /クリア/ }));
+
+      expect(onClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reset form fields when clear button is clicked", async () => {
+      const { user } = render(
+        <SalesPersonsSearchForm
+          {...defaultProps}
+          defaultValues={{ name: "山田", department: "_all" }}
+        />,
+        { user: mockAdminUser }
+      );
+
+      await user.type(screen.getByLabelText("氏名"), "追加テキスト");
+      await user.click(screen.getByRole("button", { name: /クリア/ }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("氏名")).toHaveValue("");
+      });
+    });
+  });
+
+  describe("loading state", () => {
+    it("should disable inputs when loading", () => {
+      render(<SalesPersonsSearchForm {...defaultProps} isLoading={true} />, {
+        user: mockAdminUser,
+      });
+
+      expect(screen.getByLabelText("氏名")).toBeDisabled();
+    });
+
+    it("should disable buttons when loading", () => {
+      render(<SalesPersonsSearchForm {...defaultProps} isLoading={true} />, {
+        user: mockAdminUser,
+      });
+
+      expect(screen.getByRole("button", { name: /検索/ })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /クリア/ })).toBeDisabled();
+    });
+  });
+});

--- a/src/features/sales-persons/components/SalesPersonsSearchForm.tsx
+++ b/src/features/sales-persons/components/SalesPersonsSearchForm.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Search, X } from "lucide-react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { DEPARTMENTS } from "../constants";
+import { searchFormSchema } from "../schemas";
+
+import type { SearchFormValues } from "../schemas";
+
+interface SalesPersonsSearchFormProps {
+  defaultValues?: SearchFormValues;
+  onSearch: (values: SearchFormValues) => void;
+  onClear: () => void;
+  isLoading?: boolean;
+}
+
+export function SalesPersonsSearchForm({
+  defaultValues,
+  onSearch,
+  onClear,
+  isLoading,
+}: SalesPersonsSearchFormProps) {
+  const form = useForm<SearchFormValues>({
+    resolver: zodResolver(searchFormSchema),
+    defaultValues: {
+      name: defaultValues?.name || "",
+      department: defaultValues?.department || "_all",
+    },
+  });
+
+  const handleClear = () => {
+    form.reset({ name: "", department: "_all" });
+    onClear();
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSearch)} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>氏名</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="氏名で検索"
+                        disabled={isLoading}
+                        {...field}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="department"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>部署</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value ?? ""}
+                      disabled={isLoading ?? false}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="全て" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="_all">全て</SelectItem>
+                        {DEPARTMENTS.map((dept) => (
+                          <SelectItem key={dept.value} value={dept.value}>
+                            {dept.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClear}
+                disabled={isLoading}
+              >
+                <X className="mr-2 h-4 w-4" />
+                クリア
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                <Search className="mr-2 h-4 w-4" />
+                検索
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/sales-persons/components/SalesPersonsTable.test.tsx
+++ b/src/features/sales-persons/components/SalesPersonsTable.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+
+import { render, screen, mockAdminUser } from "@/test/test-utils";
+
+import { SalesPersonsTable } from "./SalesPersonsTable";
+
+import type { SalesPersonListItem } from "../types";
+
+describe("SalesPersonsTable", () => {
+  const mockSalesPersons: SalesPersonListItem[] = [
+    {
+      sales_person_id: 1,
+      name: "山田太郎",
+      email: "yamada@example.com",
+      department: "営業1課",
+      manager_id: 2,
+      manager_name: "鈴木一郎",
+      is_manager: false,
+    },
+    {
+      sales_person_id: 2,
+      name: "鈴木一郎",
+      email: "suzuki@example.com",
+      department: "営業1課",
+      manager_id: null,
+      manager_name: null,
+      is_manager: true,
+    },
+    {
+      sales_person_id: 3,
+      name: "佐藤花子",
+      email: "sato@example.com",
+      department: "営業2課",
+      manager_id: null,
+      manager_name: null,
+      is_manager: false,
+    },
+  ];
+
+  describe("rendering", () => {
+    it("should render table headers", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      expect(
+        screen.getByRole("columnheader", { name: "No" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "氏名" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "部署" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "上長" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "権限" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "操作" })
+      ).toBeInTheDocument();
+    });
+
+    it("should render sales person data in rows", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      expect(screen.getByText("山田太郎")).toBeInTheDocument();
+      // 鈴木一郎は本人の行と山田太郎の上長として2回出現
+      expect(screen.getAllByText("鈴木一郎").length).toBe(2);
+      expect(screen.getByText("佐藤花子")).toBeInTheDocument();
+
+      expect(screen.getAllByText("営業1課").length).toBe(2);
+      expect(screen.getByText("営業2課")).toBeInTheDocument();
+    });
+
+    it("should display '-' for null manager_name", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      // manager_nameがnullのユーザーは2人
+      const dashes = screen.getAllByText("-");
+      expect(dashes.length).toBe(2);
+    });
+
+    it("should render correct row numbers", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("should render correct row numbers with startIndex", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={20} />,
+        { user: mockAdminUser }
+      );
+
+      expect(screen.getByText("21")).toBeInTheDocument();
+      expect(screen.getByText("22")).toBeInTheDocument();
+      expect(screen.getByText("23")).toBeInTheDocument();
+    });
+
+    it("should display role badges correctly", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      // 一般2人、上長1人（バッジのみをカウント）
+      const generalBadges = screen.getAllByText("一般");
+      expect(generalBadges.length).toBe(2);
+
+      // "上長" はヘッダーとバッジ両方に存在する
+      const allManagerTexts = screen.getAllByText("上長");
+      // ヘッダー1 + バッジ1 = 2
+      expect(allManagerTexts.length).toBe(2);
+    });
+  });
+
+  describe("empty state", () => {
+    it("should show empty message when no sales persons", () => {
+      render(<SalesPersonsTable salesPersons={[]} startIndex={0} />, {
+        user: mockAdminUser,
+      });
+
+      expect(
+        screen.getByText("該当する営業担当者が見つかりませんでした")
+      ).toBeInTheDocument();
+    });
+
+    it("should not render table when empty", () => {
+      render(<SalesPersonsTable salesPersons={[]} startIndex={0} />, {
+        user: mockAdminUser,
+      });
+
+      expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("edit links", () => {
+    it("should render edit buttons for each row", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      const editLinks = screen.getAllByRole("link", { name: /編集/ });
+      expect(editLinks.length).toBe(3);
+    });
+
+    it("should have correct edit link href", () => {
+      render(
+        <SalesPersonsTable salesPersons={mockSalesPersons} startIndex={0} />,
+        { user: mockAdminUser }
+      );
+
+      const editLinks = screen.getAllByRole("link", { name: /編集/ });
+      expect(editLinks[0]).toHaveAttribute("href", "/sales-persons/1/edit");
+      expect(editLinks[1]).toHaveAttribute("href", "/sales-persons/2/edit");
+      expect(editLinks[2]).toHaveAttribute("href", "/sales-persons/3/edit");
+    });
+  });
+});

--- a/src/features/sales-persons/components/SalesPersonsTable.tsx
+++ b/src/features/sales-persons/components/SalesPersonsTable.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Edit } from "lucide-react";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { getRoleLabel } from "../constants";
+
+import type { SalesPersonListItem } from "../types";
+
+interface SalesPersonsTableProps {
+  salesPersons: SalesPersonListItem[];
+  startIndex: number;
+}
+
+export function SalesPersonsTable({
+  salesPersons,
+  startIndex,
+}: SalesPersonsTableProps) {
+  if (salesPersons.length === 0) {
+    return (
+      <div className="flex h-32 items-center justify-center rounded-md border text-muted-foreground">
+        該当する営業担当者が見つかりませんでした
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-16">No</TableHead>
+            <TableHead>氏名</TableHead>
+            <TableHead>部署</TableHead>
+            <TableHead>上長</TableHead>
+            <TableHead className="w-24">権限</TableHead>
+            <TableHead className="w-24">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {salesPersons.map((person, index) => (
+            <TableRow key={person.sales_person_id}>
+              <TableCell className="font-medium">
+                {startIndex + index + 1}
+              </TableCell>
+              <TableCell>{person.name}</TableCell>
+              <TableCell>{person.department}</TableCell>
+              <TableCell>{person.manager_name || "-"}</TableCell>
+              <TableCell>
+                <Badge variant={person.is_manager ? "default" : "secondary"}>
+                  {getRoleLabel(person.is_manager)}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href={`/sales-persons/${person.sales_person_id}/edit`}>
+                    <Edit className="mr-1 h-4 w-4" />
+                    編集
+                  </Link>
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/sales-persons/components/index.ts
+++ b/src/features/sales-persons/components/index.ts
@@ -1,0 +1,7 @@
+export { SalesPersonEditContainer } from "./SalesPersonEditContainer";
+export { SalesPersonEditForm } from "./SalesPersonEditForm";
+export { SalesPersonForm } from "./SalesPersonForm";
+export { SalesPersonsList } from "./SalesPersonsList";
+export { SalesPersonsListSkeleton } from "./SalesPersonsListSkeleton";
+export { SalesPersonsSearchForm } from "./SalesPersonsSearchForm";
+export { SalesPersonsTable } from "./SalesPersonsTable";

--- a/src/features/sales-persons/constants.test.ts
+++ b/src/features/sales-persons/constants.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  DEPARTMENTS,
+  ROLES,
+  isManagerToRoleValue,
+  roleValueToIsManager,
+  getRoleLabel,
+  SALES_PERSONS_API_BASE,
+  DEFAULT_PER_PAGE,
+} from "./constants";
+
+describe("DEPARTMENTS", () => {
+  it("should have 4 departments", () => {
+    expect(DEPARTMENTS).toHaveLength(4);
+  });
+
+  it("should contain required departments", () => {
+    const departmentValues = DEPARTMENTS.map((d) => d.value);
+    expect(departmentValues).toContain("営業1課");
+    expect(departmentValues).toContain("営業2課");
+    expect(departmentValues).toContain("営業3課");
+    expect(departmentValues).toContain("管理部");
+  });
+
+  it("should have value and label for each department", () => {
+    DEPARTMENTS.forEach((dept) => {
+      expect(dept).toHaveProperty("value");
+      expect(dept).toHaveProperty("label");
+      expect(typeof dept.value).toBe("string");
+      expect(typeof dept.label).toBe("string");
+    });
+  });
+});
+
+describe("ROLES", () => {
+  it("should have 2 roles", () => {
+    expect(ROLES).toHaveLength(2);
+  });
+
+  it("should contain 'general' and 'manager' roles", () => {
+    const roleValues = ROLES.map((r) => r.value);
+    expect(roleValues).toContain("general");
+    expect(roleValues).toContain("manager");
+  });
+
+  it("should have correct isManager mapping", () => {
+    const generalRole = ROLES.find((r) => r.value === "general");
+    const managerRole = ROLES.find((r) => r.value === "manager");
+
+    expect(generalRole?.isManager).toBe(false);
+    expect(managerRole?.isManager).toBe(true);
+  });
+
+  it("should have correct labels", () => {
+    const generalRole = ROLES.find((r) => r.value === "general");
+    const managerRole = ROLES.find((r) => r.value === "manager");
+
+    expect(generalRole?.label).toBe("一般");
+    expect(managerRole?.label).toBe("上長");
+  });
+});
+
+describe("isManagerToRoleValue", () => {
+  it("should return 'general' for false", () => {
+    expect(isManagerToRoleValue(false)).toBe("general");
+  });
+
+  it("should return 'manager' for true", () => {
+    expect(isManagerToRoleValue(true)).toBe("manager");
+  });
+});
+
+describe("roleValueToIsManager", () => {
+  it("should return false for 'general'", () => {
+    expect(roleValueToIsManager("general")).toBe(false);
+  });
+
+  it("should return true for 'manager'", () => {
+    expect(roleValueToIsManager("manager")).toBe(true);
+  });
+});
+
+describe("getRoleLabel", () => {
+  it("should return '一般' for false", () => {
+    expect(getRoleLabel(false)).toBe("一般");
+  });
+
+  it("should return '上長' for true", () => {
+    expect(getRoleLabel(true)).toBe("上長");
+  });
+});
+
+describe("constants", () => {
+  it("should have correct API base path", () => {
+    expect(SALES_PERSONS_API_BASE).toBe("/api/v1/sales-persons");
+  });
+
+  it("should have correct default per page value", () => {
+    expect(DEFAULT_PER_PAGE).toBe(20);
+  });
+});

--- a/src/features/sales-persons/constants.ts
+++ b/src/features/sales-persons/constants.ts
@@ -1,0 +1,64 @@
+/**
+ * 営業担当者マスタ画面の定数
+ */
+
+/**
+ * 部署の選択肢
+ */
+export const DEPARTMENTS = [
+  { value: "営業1課", label: "営業1課" },
+  { value: "営業2課", label: "営業2課" },
+  { value: "営業3課", label: "営業3課" },
+  { value: "管理部", label: "管理部" },
+] as const;
+
+/**
+ * 部署の値の型
+ */
+export type DepartmentValue = (typeof DEPARTMENTS)[number]["value"];
+
+/**
+ * 権限の選択肢
+ * - 一般: is_manager = false
+ * - 上長: is_manager = true
+ */
+export const ROLES = [
+  { value: "general", label: "一般", isManager: false },
+  { value: "manager", label: "上長", isManager: true },
+] as const;
+
+/**
+ * 権限値の型
+ */
+export type RoleValue = (typeof ROLES)[number]["value"];
+
+/**
+ * is_managerから権限値に変換
+ */
+export function isManagerToRoleValue(isManager: boolean): RoleValue {
+  return isManager ? "manager" : "general";
+}
+
+/**
+ * 権限値からis_managerに変換
+ */
+export function roleValueToIsManager(roleValue: RoleValue): boolean {
+  return roleValue === "manager";
+}
+
+/**
+ * 権限値から表示ラベルを取得
+ */
+export function getRoleLabel(isManager: boolean): string {
+  return isManager ? "上長" : "一般";
+}
+
+/**
+ * APIエンドポイント
+ */
+export const SALES_PERSONS_API_BASE = "/api/v1/sales-persons";
+
+/**
+ * 1ページあたりの表示件数
+ */
+export const DEFAULT_PER_PAGE = 20;

--- a/src/features/sales-persons/index.ts
+++ b/src/features/sales-persons/index.ts
@@ -1,0 +1,5 @@
+export * from "./api";
+export * from "./components";
+export * from "./constants";
+export * from "./schemas";
+export * from "./types";

--- a/src/features/sales-persons/schemas.test.ts
+++ b/src/features/sales-persons/schemas.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  createSalesPersonFormSchema,
+  updateSalesPersonFormSchema,
+  searchFormSchema,
+  convertFormToApiRequest,
+} from "./schemas";
+
+describe("createSalesPersonFormSchema", () => {
+  describe("name validation", () => {
+    it("should fail when name is empty", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("氏名を入力してください");
+      }
+    });
+
+    it("should fail when name exceeds 50 characters", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "あ".repeat(51),
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "氏名は50文字以内で入力してください"
+        );
+      }
+    });
+
+    it("should pass with valid name", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("email validation", () => {
+    it("should fail when email is empty", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "メールアドレスを入力してください"
+        );
+      }
+    });
+
+    it("should fail for invalid email format", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "invalid-email",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "正しいメールアドレス形式で入力してください"
+        );
+      }
+    });
+  });
+
+  describe("password validation", () => {
+    it("should fail when password is less than 8 characters", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "1234567",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "パスワードは8文字以上で入力してください"
+        );
+      }
+    });
+
+    it("should pass with 8+ character password", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("department validation", () => {
+    it("should fail when department is empty", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("部署を選択してください");
+      }
+    });
+  });
+
+  describe("role validation", () => {
+    it("should accept 'general' role", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept 'manager' role", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "manager",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid role", () => {
+      const result = createSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "invalid",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("updateSalesPersonFormSchema", () => {
+  describe("password validation", () => {
+    it("should allow empty password", () => {
+      const result = updateSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should fail when password is provided but less than 8 characters", () => {
+      const result = updateSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "1234567",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "パスワードは8文字以上で入力してください"
+        );
+      }
+    });
+
+    it("should pass when password is 8+ characters", () => {
+      const result = updateSalesPersonFormSchema.safeParse({
+        name: "山田太郎",
+        email: "test@example.com",
+        password: "12345678",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe("searchFormSchema", () => {
+  it("should allow all fields to be empty", () => {
+    const result = searchFormSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept name search", () => {
+    const result = searchFormSchema.safeParse({
+      name: "山田",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("山田");
+    }
+  });
+
+  it("should accept department search", () => {
+    const result = searchFormSchema.safeParse({
+      department: "営業1課",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.department).toBe("営業1課");
+    }
+  });
+});
+
+describe("convertFormToApiRequest", () => {
+  describe("create mode (isEdit = false)", () => {
+    it("should include password in create mode", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.password).toBe("password123");
+      expect(result.name).toBe("山田太郎");
+      expect(result.email).toBe("yamada@example.com");
+      expect(result.department).toBe("営業1課");
+      expect(result.manager_id).toBe(null);
+      expect(result.is_manager).toBe(false);
+    });
+
+    it("should convert 'manager' role to is_manager=true", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "manager" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.is_manager).toBe(true);
+    });
+
+    it("should parse manager_id as number", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "10",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.manager_id).toBe(10);
+    });
+  });
+
+  describe("edit mode (isEdit = true)", () => {
+    it("should not include password when empty in edit mode", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, true);
+
+      expect(result.password).toBeUndefined();
+    });
+
+    it("should include password when provided in edit mode", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "newpassword123",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, true);
+
+      expect(result.password).toBe("newpassword123");
+    });
+  });
+
+  describe("manager_id handling", () => {
+    it("should return null for _none manager_id", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "_none",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.manager_id).toBe(null);
+    });
+
+    it("should return null for empty manager_id", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.manager_id).toBe(null);
+    });
+
+    it("should return null for invalid manager_id", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "invalid",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.manager_id).toBe(null);
+    });
+
+    it("should parse valid manager_id", () => {
+      const formData = {
+        name: "山田太郎",
+        email: "yamada@example.com",
+        password: "password123",
+        department: "営業1課",
+        manager_id: "5",
+        role: "general" as const,
+      };
+
+      const result = convertFormToApiRequest(formData, false);
+
+      expect(result.manager_id).toBe(5);
+    });
+  });
+});

--- a/src/features/sales-persons/schemas.ts
+++ b/src/features/sales-persons/schemas.ts
@@ -1,0 +1,117 @@
+/**
+ * 営業担当者マスタ画面のバリデーションスキーマ
+ */
+
+import { z } from "zod";
+
+/**
+ * フォーム入力のベーススキーマ（共通項目）
+ */
+const baseFormSchema = {
+  name: z
+    .string()
+    .min(1, "氏名を入力してください")
+    .max(50, "氏名は50文字以内で入力してください"),
+  email: z
+    .string()
+    .min(1, "メールアドレスを入力してください")
+    .email("正しいメールアドレス形式で入力してください"),
+  department: z.string().min(1, "部署を選択してください"),
+  manager_id: z.string(), // 空文字列は「なし」として扱う
+  role: z.enum(["general", "manager"], {
+    required_error: "権限を選択してください",
+  }),
+};
+
+/**
+ * 新規登録フォームのスキーマ
+ */
+export const createSalesPersonFormSchema = z.object({
+  ...baseFormSchema,
+  password: z.string().min(8, "パスワードは8文字以上で入力してください"),
+});
+
+/**
+ * 新規登録フォームの入力値型
+ */
+export type CreateSalesPersonFormValues = z.infer<
+  typeof createSalesPersonFormSchema
+>;
+
+/**
+ * 編集フォームのスキーマ
+ * パスワードは任意（空の場合は変更しない）
+ */
+export const updateSalesPersonFormSchema = z.object({
+  ...baseFormSchema,
+  password: z
+    .string()
+    .refine(
+      (val) => val === "" || val.length >= 8,
+      "パスワードは8文字以上で入力してください"
+    ),
+});
+
+/**
+ * 編集フォームの入力値型
+ */
+export type UpdateSalesPersonFormValues = z.infer<
+  typeof updateSalesPersonFormSchema
+>;
+
+/**
+ * 検索フォームのスキーマ
+ */
+export const searchFormSchema = z.object({
+  name: z.string().optional(),
+  department: z.string().optional(),
+});
+
+export type SearchFormValues = z.infer<typeof searchFormSchema>;
+
+/**
+ * フォーム値をAPIリクエスト形式に変換
+ */
+export function convertFormToApiRequest(
+  formData: CreateSalesPersonFormValues | UpdateSalesPersonFormValues,
+  isEdit: boolean
+): {
+  name: string;
+  email: string;
+  password?: string;
+  department: string;
+  manager_id: number | null;
+  is_manager: boolean;
+} {
+  const { name, email, password, department, manager_id, role } = formData;
+
+  // "_none" は「なし」を表す特殊値
+  const managerId =
+    manager_id && manager_id !== "" && manager_id !== "_none"
+      ? parseInt(manager_id, 10)
+      : null;
+
+  const result: {
+    name: string;
+    email: string;
+    password?: string;
+    department: string;
+    manager_id: number | null;
+    is_manager: boolean;
+  } = {
+    name,
+    email,
+    department,
+    manager_id: isNaN(managerId as number) ? null : managerId,
+    is_manager: role === "manager",
+  };
+
+  // パスワードは新規の場合は必須、編集の場合は入力があった時のみ含める
+  if (!isEdit) {
+    result.password = password;
+  } else if (password && password.length > 0) {
+    result.password = password;
+  }
+
+  return result;
+}

--- a/src/features/sales-persons/types.ts
+++ b/src/features/sales-persons/types.ts
@@ -1,0 +1,107 @@
+/**
+ * 営業担当者マスタ画面の型定義
+ */
+
+/**
+ * 営業担当者一覧項目
+ */
+export interface SalesPersonListItem {
+  sales_person_id: number;
+  name: string;
+  email: string;
+  department: string;
+  manager_id: number | null;
+  manager_name: string | null;
+  is_manager: boolean;
+}
+
+/**
+ * 営業担当者詳細レスポンス
+ */
+export interface SalesPersonResponse {
+  sales_person_id: number;
+  name: string;
+  email: string;
+  department: string;
+  manager_id: number | null;
+  manager_name: string | null;
+  is_manager: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * ページネーション情報
+ */
+export interface Pagination {
+  total: number;
+  per_page: number;
+  current_page: number;
+  last_page: number;
+}
+
+/**
+ * 一覧取得APIレスポンス
+ */
+export interface SalesPersonsListResponse {
+  success: boolean;
+  data: {
+    items: SalesPersonListItem[];
+    pagination: Pagination;
+  };
+  message?: string;
+}
+
+/**
+ * 詳細取得APIレスポンス
+ */
+export interface SalesPersonDetailResponse {
+  success: boolean;
+  data: SalesPersonResponse;
+  message?: string;
+}
+
+/**
+ * 作成・更新APIレスポンス
+ */
+export interface SalesPersonMutationResponse {
+  success: boolean;
+  data: SalesPersonResponse;
+  message?: string;
+}
+
+/**
+ * 削除APIレスポンス
+ */
+export interface SalesPersonDeleteResponse {
+  success: boolean;
+  data: {
+    sales_person_id: number;
+  };
+  message?: string;
+}
+
+/**
+ * APIエラーレスポンス
+ */
+export interface ApiErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Array<{
+      field: string;
+      message: string;
+    }>;
+  };
+}
+
+/**
+ * 検索パラメータ
+ */
+export interface SearchParams {
+  name?: string;
+  department?: string;
+  page?: number;
+  per_page?: number;
+}


### PR DESCRIPTION
## Summary
- 営業担当者マスタ一覧画面 (SCR-030) の実装
- 営業担当者マスタ登録・編集画面 (SCR-031) の実装
- 氏名・部署による検索、ページネーション、CRUD機能を実装

## 実装内容

### 営業担当者マスタ一覧画面 (SCR-030)
- `/sales-persons` - 一覧ページ
- 氏名・部署による検索フォーム
- ページネーション対応
- 編集リンク

### 営業担当者マスタ登録・編集画面 (SCR-031)
- `/sales-persons/new` - 新規登録ページ
- `/sales-persons/[id]/edit` - 編集ページ
- 入力フィールド: 氏名、メールアドレス、パスワード、部署、上長、権限
- react-hook-form + zod によるバリデーション
- 削除機能（編集画面のみ）

### 技術的な追加
- `src/features/sales-persons/` - フィーチャーモジュール
- `src/components/common/Pagination.tsx` - 共通ページネーションコンポーネント
- `src/components/ui/radio-group.tsx` - shadcn/ui radio-group

## Test plan
- [ ] 73テストケースが全てパスすることを確認
- [ ] lint・typecheckがエラーなく通ることを確認
- [ ] `/sales-persons` にアクセスして一覧画面が表示されることを確認
- [ ] 検索機能が動作することを確認
- [ ] `/sales-persons/new` で新規登録ができることを確認
- [ ] `/sales-persons/[id]/edit` で編集ができることを確認
- [ ] バリデーションエラーが適切に表示されることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)