### PR TITLE
feat: Issue #11 日報API実装

### DIFF
--- a/src/app/api/v1/reports/[id]/route.ts
+++ b/src/app/api/v1/reports/[id]/route.ts
@@ -1,0 +1,397 @@
+/**
+ * 日報API - 詳細取得・更新・削除
+ *
+ * GET /api/v1/reports/{id} - 詳細取得
+ * PUT /api/v1/reports/{id} - 更新
+ * DELETE /api/v1/reports/{id} - 削除
+ */
+
+import { auth } from "@/auth";
+import { createApiError, ErrorCode } from "@/lib/api/errors";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  errorResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import {
+  getStatusLabel,
+  ReportIdParamSchema,
+  UpdateReportSchema,
+} from "@/lib/api/schemas/report";
+import { parseAndValidateBody, validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  CommentResponse,
+  ReportDetailResponse,
+  ReportStatusType,
+  UpdateReportResponse,
+  VisitRecordResponse,
+} from "@/lib/api/schemas/report";
+
+/**
+ * 訪問時間をHH:MM形式に変換
+ */
+function formatVisitTime(date: Date | null): string | null {
+  if (!date) {
+    return null;
+  }
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * 訪問時間文字列をDate型に変換
+ * HH:MM形式の文字列を1970-01-01の時間として変換
+ */
+function parseVisitTime(timeStr: string | null | undefined): Date | null {
+  if (!timeStr) {
+    return null;
+  }
+
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  const date = new Date(1970, 0, 1, hours, minutes, 0);
+  return date;
+}
+
+/**
+ * ログインユーザーが日報にアクセス可能かチェック
+ * @returns true: アクセス可能, false: アクセス不可
+ */
+async function canAccessReport(
+  userId: number,
+  isManager: boolean,
+  reportOwnerId: number
+): Promise<boolean> {
+  // 自分の日報なら常にアクセス可能
+  if (userId === reportOwnerId) {
+    return true;
+  }
+
+  // 上長でない場合はアクセス不可
+  if (!isManager) {
+    return false;
+  }
+
+  // 上長の場合、部下の日報かどうかチェック
+  const subordinate = await prisma.salesPerson.findFirst({
+    where: {
+      id: reportOwnerId,
+      managerId: userId,
+    },
+  });
+
+  return subordinate !== null;
+}
+
+/**
+ * Prismaの結果を日報詳細レスポンス形式に変換
+ */
+function toReportDetailResponse(report: {
+  id: number;
+  reportDate: Date;
+  salesPersonId: number;
+  status: string;
+  problem: string | null;
+  plan: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  salesPerson: { name: string };
+  visitRecords: Array<{
+    id: number;
+    customerId: number;
+    visitTime: Date | null;
+    visitPurpose: string | null;
+    visitContent: string;
+    visitResult: string | null;
+    customer: { customerName: string };
+  }>;
+  comments: Array<{
+    id: number;
+    salesPersonId: number;
+    commentText: string;
+    createdAt: Date;
+    salesPerson: { name: string };
+  }>;
+}): ReportDetailResponse {
+  const status = report.status as ReportStatusType;
+  const dateStr = report.reportDate.toISOString().split("T")[0];
+
+  const visits: VisitRecordResponse[] = report.visitRecords.map((v) => ({
+    visit_id: v.id,
+    customer_id: v.customerId,
+    customer_name: v.customer.customerName,
+    visit_time: formatVisitTime(v.visitTime),
+    visit_purpose: v.visitPurpose,
+    visit_content: v.visitContent,
+    visit_result: v.visitResult,
+  }));
+
+  const comments: CommentResponse[] = report.comments.map((c) => ({
+    comment_id: c.id,
+    sales_person_id: c.salesPersonId,
+    sales_person_name: c.salesPerson.name,
+    comment_text: c.commentText,
+    created_at: c.createdAt.toISOString(),
+  }));
+
+  return {
+    report_id: report.id,
+    report_date: dateStr ?? "",
+    sales_person_id: report.salesPersonId,
+    sales_person_name: report.salesPerson.name,
+    status,
+    status_label: getStatusLabel(status),
+    problem: report.problem,
+    plan: report.plan,
+    visits,
+    comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  };
+}
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * GET /api/v1/reports/{id}
+   * 日報の詳細を取得
+   */
+  GET: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id } = validatePathParams(params, ReportIdParamSchema);
+
+    // 日報を取得
+    const report = await prisma.dailyReport.findUnique({
+      where: { id },
+      include: {
+        salesPerson: {
+          select: { name: true },
+        },
+        visitRecords: {
+          include: {
+            customer: {
+              select: { customerName: true },
+            },
+          },
+          orderBy: { visitTime: "asc" },
+        },
+        comments: {
+          include: {
+            salesPerson: {
+              select: { name: true },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    if (!report) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // アクセス権限チェック
+    const canAccess = await canAccessReport(
+      session.user.id,
+      session.user.isManager,
+      report.salesPersonId
+    );
+
+    if (!canAccess) {
+      return forbiddenResponse("この日報を閲覧する権限がありません");
+    }
+
+    return successResponse(toReportDetailResponse(report));
+  },
+
+  /**
+   * PUT /api/v1/reports/{id}
+   * 日報を更新
+   */
+  PUT: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id } = validatePathParams(params, ReportIdParamSchema);
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, UpdateReportSchema);
+
+    // 対象の日報が存在するかチェック
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id },
+    });
+
+    if (!existingReport) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // 本人のみ編集可能
+    if (existingReport.salesPersonId !== session.user.id) {
+      return forbiddenResponse("この日報を編集する権限がありません");
+    }
+
+    // 確認済の日報は編集不可
+    if (existingReport.status === "confirmed") {
+      return errorResponse(
+        ErrorCode.FORBIDDEN_EDIT,
+        "確認済の日報は編集できません"
+      );
+    }
+
+    // 日付変更時、同一日の日報が既に存在するかチェック
+    const newReportDate = new Date(body.report_date);
+    const existingReportDate = existingReport.reportDate;
+
+    if (newReportDate.getTime() !== existingReportDate.getTime()) {
+      const duplicateReport = await prisma.dailyReport.findUnique({
+        where: {
+          salesPersonId_reportDate: {
+            salesPersonId: session.user.id,
+            reportDate: newReportDate,
+          },
+        },
+      });
+
+      if (duplicateReport) {
+        throw createApiError.duplicateEntry(
+          "この日付の日報は既に作成されています"
+        );
+      }
+    }
+
+    // 訪問記録の顧客IDが存在するかチェック
+    if (body.visits && body.visits.length > 0) {
+      const customerIds = body.visits.map((v) => v.customer_id);
+      const existingCustomers = await prisma.customer.findMany({
+        where: { id: { in: customerIds } },
+        select: { id: true },
+      });
+      const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+
+      for (const visit of body.visits) {
+        if (!existingCustomerIds.has(visit.customer_id)) {
+          throw createApiError.validationError("指定された顧客が存在しません", [
+            {
+              field: "visits",
+              message: `顧客ID ${visit.customer_id} が存在しません`,
+            },
+          ]);
+        }
+      }
+    }
+
+    // トランザクションで日報と訪問記録を更新
+    const updatedReport = await prisma.$transaction(async (tx) => {
+      // 既存の訪問記録を削除
+      await tx.visitRecord.deleteMany({
+        where: { reportId: id },
+      });
+
+      // 日報を更新
+      const report = await tx.dailyReport.update({
+        where: { id },
+        data: {
+          reportDate: newReportDate,
+          problem: body.problem ?? null,
+          plan: body.plan ?? null,
+          status: body.status,
+        },
+      });
+
+      // 訪問記録を再作成
+      if (body.visits && body.visits.length > 0) {
+        await tx.visitRecord.createMany({
+          data: body.visits.map((visit) => ({
+            reportId: id,
+            customerId: visit.customer_id,
+            visitTime: parseVisitTime(visit.visit_time),
+            visitPurpose: visit.visit_purpose ?? null,
+            visitContent: visit.visit_content,
+            visitResult: visit.visit_result ?? null,
+          })),
+        });
+      }
+
+      return report;
+    });
+
+    const updatedDateStr = updatedReport.reportDate.toISOString().split("T")[0];
+    const response: UpdateReportResponse = {
+      report_id: updatedReport.id,
+      report_date: updatedDateStr ?? "",
+      status: updatedReport.status as ReportStatusType,
+      updated_at: updatedReport.updatedAt.toISOString(),
+    };
+
+    return successResponse(response, { message: "日報を更新しました" });
+  },
+
+  /**
+   * DELETE /api/v1/reports/{id}
+   * 日報を削除
+   */
+  DELETE: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id } = validatePathParams(params, ReportIdParamSchema);
+
+    // 対象の日報が存在するかチェック
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id },
+    });
+
+    if (!existingReport) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // 本人のみ削除可能
+    if (existingReport.salesPersonId !== session.user.id) {
+      return forbiddenResponse("この日報を削除する権限がありません");
+    }
+
+    // 下書きのみ削除可能
+    if (existingReport.status !== "draft") {
+      return errorResponse(
+        ErrorCode.FORBIDDEN_DELETE,
+        "下書き以外の日報は削除できません"
+      );
+    }
+
+    // 日報を削除（訪問記録、コメントはCascadeで自動削除）
+    await prisma.dailyReport.delete({
+      where: { id },
+    });
+
+    return successResponse(
+      { report_id: id },
+      { message: "日報を削除しました" }
+    );
+  },
+});
+
+export const GET = handlers.GET!;
+export const PUT = handlers.PUT!;
+export const DELETE = handlers.DELETE!;

--- a/src/app/api/v1/reports/[id]/status/route.ts
+++ b/src/app/api/v1/reports/[id]/status/route.ts
@@ -1,0 +1,143 @@
+/**
+ * 日報ステータス更新API
+ *
+ * PATCH /api/v1/reports/{id}/status - ステータス更新
+ */
+
+import { auth } from "@/auth";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import {
+  getStatusLabel,
+  ReportIdParamSchema,
+  UpdateStatusSchema,
+} from "@/lib/api/schemas/report";
+import { parseAndValidateBody, validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  ReportStatusType,
+  UpdateStatusResponse,
+} from "@/lib/api/schemas/report";
+
+/**
+ * ログインユーザーが日報にアクセス可能かチェック
+ * @returns true: アクセス可能, false: アクセス不可
+ */
+async function canAccessReport(
+  userId: number,
+  isManager: boolean,
+  reportOwnerId: number
+): Promise<boolean> {
+  // 自分の日報なら常にアクセス可能
+  if (userId === reportOwnerId) {
+    return true;
+  }
+
+  // 上長でない場合はアクセス不可
+  if (!isManager) {
+    return false;
+  }
+
+  // 上長の場合、部下の日報かどうかチェック
+  const subordinate = await prisma.salesPerson.findFirst({
+    where: {
+      id: reportOwnerId,
+      managerId: userId,
+    },
+  });
+
+  return subordinate !== null;
+}
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * PATCH /api/v1/reports/{id}/status
+   * 日報のステータスを更新
+   */
+  PATCH: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id } = validatePathParams(params, ReportIdParamSchema);
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, UpdateStatusSchema);
+
+    // 対象の日報が存在するかチェック
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id },
+    });
+
+    if (!existingReport) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // アクセス権限チェック
+    const canAccess = await canAccessReport(
+      session.user.id,
+      session.user.isManager,
+      existingReport.salesPersonId
+    );
+
+    if (!canAccess) {
+      return forbiddenResponse(
+        "この日報のステータスを更新する権限がありません"
+      );
+    }
+
+    // confirmedへの変更は上長のみ可能
+    if (body.status === "confirmed") {
+      // 日報の作成者本人がconfirmedにしようとしている場合はエラー
+      if (existingReport.salesPersonId === session.user.id) {
+        return forbiddenResponse(
+          "自分の日報を確認済にすることはできません。上長に確認を依頼してください"
+        );
+      }
+
+      // 上長でない場合もエラー
+      if (!session.user.isManager) {
+        return forbiddenResponse("確認済ステータスへの変更は上長のみ可能です");
+      }
+    }
+
+    // 本人以外はdraft/submittedへの変更不可
+    if (
+      body.status !== "confirmed" &&
+      existingReport.salesPersonId !== session.user.id
+    ) {
+      return forbiddenResponse(
+        "他人の日報のステータスを下書きまたは提出済に変更することはできません"
+      );
+    }
+
+    // ステータスを更新
+    const updatedReport = await prisma.dailyReport.update({
+      where: { id },
+      data: {
+        status: body.status,
+      },
+    });
+
+    const response: UpdateStatusResponse = {
+      report_id: updatedReport.id,
+      status: updatedReport.status as ReportStatusType,
+      status_label: getStatusLabel(updatedReport.status as ReportStatusType),
+      updated_at: updatedReport.updatedAt.toISOString(),
+    };
+
+    return successResponse(response, { message: "ステータスを更新しました" });
+  },
+});
+
+export const PATCH = handlers.PATCH!;

--- a/src/app/api/v1/reports/route.ts
+++ b/src/app/api/v1/reports/route.ts
@@ -1,0 +1,297 @@
+/**
+ * 日報API - 一覧取得・新規作成
+ *
+ * GET /api/v1/reports - 一覧取得（ページネーション対応）
+ * POST /api/v1/reports - 新規作成
+ */
+
+import { auth } from "@/auth";
+import { createApiError } from "@/lib/api/errors";
+import { createHandlers } from "@/lib/api/handler";
+import { calculateOffset, calculatePagination } from "@/lib/api/pagination";
+import {
+  createdResponse,
+  forbiddenResponse,
+  paginatedResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import {
+  CreateReportSchema,
+  getStatusLabel,
+  ReportsQuerySchema,
+} from "@/lib/api/schemas/report";
+import {
+  parseAndValidateBody,
+  searchParamsToObject,
+} from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  CreateReportResponse,
+  ReportListItem,
+  ReportStatusType,
+} from "@/lib/api/schemas/report";
+import type { Prisma } from "@prisma/client";
+
+/**
+ * 訪問時間文字列をDate型に変換
+ * HH:MM形式の文字列を1970-01-01の時間として変換
+ */
+function parseVisitTime(timeStr: string | null | undefined): Date | null {
+  if (!timeStr) {
+    return null;
+  }
+
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  const date = new Date(1970, 0, 1, hours, minutes, 0);
+  return date;
+}
+
+/**
+ * Prismaの結果を日報一覧レスポンス形式に変換
+ */
+function toReportListItem(report: {
+  id: number;
+  reportDate: Date;
+  salesPersonId: number;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  salesPerson: { name: string };
+  _count: {
+    visitRecords: number;
+    comments: number;
+  };
+}): ReportListItem {
+  const status = report.status as ReportStatusType;
+  const dateStr = report.reportDate.toISOString().split("T")[0];
+  return {
+    report_id: report.id,
+    report_date: dateStr ?? "",
+    sales_person_id: report.salesPersonId,
+    sales_person_name: report.salesPerson.name,
+    status,
+    status_label: getStatusLabel(status),
+    visit_count: report._count.visitRecords,
+    comment_count: report._count.comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  };
+}
+
+const handlers = createHandlers({
+  /**
+   * GET /api/v1/reports
+   * 日報一覧を取得
+   */
+  GET: async (request) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // クエリパラメータのバリデーション
+    const { searchParams } = new URL(request.url);
+    const queryParams = searchParamsToObject(searchParams);
+    const query = ReportsQuerySchema.parse(queryParams);
+
+    // 検索条件を構築
+    const where: Prisma.DailyReportWhereInput = {};
+
+    // 日付範囲フィルター
+    if (query.date_from || query.date_to) {
+      where.reportDate = {};
+      if (query.date_from) {
+        where.reportDate.gte = new Date(query.date_from);
+      }
+      if (query.date_to) {
+        where.reportDate.lte = new Date(query.date_to);
+      }
+    }
+
+    // ステータスフィルター
+    if (query.status) {
+      where.status = query.status;
+    }
+
+    // 権限チェック: 営業担当者は自分の日報のみ、上長は部下の日報も取得可能
+    if (!session.user.isManager) {
+      // 一般営業担当者は自分の日報のみ
+      where.salesPersonId = session.user.id;
+    } else {
+      // 上長の場合
+      if (query.sales_person_id) {
+        // 指定された営業担当者でフィルター
+        // 自分または部下の日報のみ取得可能
+        const subordinateIds = await prisma.salesPerson.findMany({
+          where: { managerId: session.user.id },
+          select: { id: true },
+        });
+        const accessibleIds = [
+          session.user.id,
+          ...subordinateIds.map((s) => s.id),
+        ];
+
+        if (!accessibleIds.includes(query.sales_person_id)) {
+          return forbiddenResponse(
+            "指定された営業担当者の日報を閲覧する権限がありません"
+          );
+        }
+        where.salesPersonId = query.sales_person_id;
+      } else {
+        // 全体取得時は自分と部下の日報
+        const subordinateIds = await prisma.salesPerson.findMany({
+          where: { managerId: session.user.id },
+          select: { id: true },
+        });
+        where.salesPersonId = {
+          in: [session.user.id, ...subordinateIds.map((s) => s.id)],
+        };
+      }
+    }
+
+    // 総件数を取得
+    const total = await prisma.dailyReport.count({ where });
+
+    // ページネーション計算
+    const { skip, take } = calculateOffset(query.page, query.per_page);
+    const pagination = calculatePagination({
+      page: query.page,
+      perPage: query.per_page,
+      total,
+    });
+
+    // ソート条件を構築
+    const orderBy: Prisma.DailyReportOrderByWithRelationInput = {};
+    if (query.sort === "report_date") {
+      orderBy.reportDate = query.order;
+    } else {
+      orderBy.createdAt = query.order;
+    }
+
+    // データ取得
+    const reports = await prisma.dailyReport.findMany({
+      where,
+      skip,
+      take,
+      orderBy,
+      select: {
+        id: true,
+        reportDate: true,
+        salesPersonId: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        salesPerson: {
+          select: { name: true },
+        },
+        _count: {
+          select: {
+            visitRecords: true,
+            comments: true,
+          },
+        },
+      },
+    });
+
+    const items = reports.map(toReportListItem);
+
+    return paginatedResponse(items, pagination);
+  },
+
+  /**
+   * POST /api/v1/reports
+   * 日報を新規作成
+   */
+  POST: async (request) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, CreateReportSchema);
+
+    // 同一日の日報が既に存在するかチェック
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: {
+        salesPersonId_reportDate: {
+          salesPersonId: session.user.id,
+          reportDate: new Date(body.report_date),
+        },
+      },
+    });
+
+    if (existingReport) {
+      throw createApiError.duplicateEntry(
+        "この日付の日報は既に作成されています"
+      );
+    }
+
+    // 訪問記録の顧客IDが存在するかチェック
+    if (body.visits && body.visits.length > 0) {
+      const customerIds = body.visits.map((v) => v.customer_id);
+      const existingCustomers = await prisma.customer.findMany({
+        where: { id: { in: customerIds } },
+        select: { id: true },
+      });
+      const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+
+      for (const visit of body.visits) {
+        if (!existingCustomerIds.has(visit.customer_id)) {
+          throw createApiError.validationError("指定された顧客が存在しません", [
+            {
+              field: "visits",
+              message: `顧客ID ${visit.customer_id} が存在しません`,
+            },
+          ]);
+        }
+      }
+    }
+
+    // トランザクションで日報と訪問記録を作成
+    const report = await prisma.$transaction(async (tx) => {
+      // 日報を作成
+      const newReport = await tx.dailyReport.create({
+        data: {
+          salesPersonId: session.user.id,
+          reportDate: new Date(body.report_date),
+          problem: body.problem ?? null,
+          plan: body.plan ?? null,
+          status: body.status,
+        },
+      });
+
+      // 訪問記録を作成
+      if (body.visits && body.visits.length > 0) {
+        await tx.visitRecord.createMany({
+          data: body.visits.map((visit) => ({
+            reportId: newReport.id,
+            customerId: visit.customer_id,
+            visitTime: parseVisitTime(visit.visit_time),
+            visitPurpose: visit.visit_purpose ?? null,
+            visitContent: visit.visit_content,
+            visitResult: visit.visit_result ?? null,
+          })),
+        });
+      }
+
+      return newReport;
+    });
+
+    const reportDateStr = report.reportDate.toISOString().split("T")[0];
+    const response: CreateReportResponse = {
+      report_id: report.id,
+      report_date: reportDateStr ?? "",
+      status: report.status as ReportStatusType,
+      created_at: report.createdAt.toISOString(),
+    };
+
+    return createdResponse(response, "日報を作成しました");
+  },
+});
+
+export const GET = handlers.GET!;
+export const POST = handlers.POST!;

--- a/src/lib/api/schemas/report.test.ts
+++ b/src/lib/api/schemas/report.test.ts
@@ -1,0 +1,436 @@
+/**
+ * 日報APIスキーマのテスト
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  CreateReportSchema,
+  getStatusLabel,
+  ReportIdParamSchema,
+  ReportsQuerySchema,
+  ReportStatus,
+  UpdateReportSchema,
+  UpdateStatusSchema,
+  VisitRecordSchema,
+} from "./report";
+
+// 日付関連のテストで固定の日付を使用するためのヘルパー
+function getYesterday(): string {
+  const date = new Date();
+  date.setDate(date.getDate() - 1);
+  return date.toISOString().split("T")[0] as string;
+}
+
+function getToday(): string {
+  return new Date().toISOString().split("T")[0] as string;
+}
+
+function getTomorrow(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+  return date.toISOString().split("T")[0] as string;
+}
+
+describe("ReportStatus", () => {
+  it("ステータス値が正しく定義されている", () => {
+    expect(ReportStatus.DRAFT).toBe("draft");
+    expect(ReportStatus.SUBMITTED).toBe("submitted");
+    expect(ReportStatus.CONFIRMED).toBe("confirmed");
+  });
+});
+
+describe("getStatusLabel", () => {
+  it("draftを下書きに変換する", () => {
+    expect(getStatusLabel("draft")).toBe("下書き");
+  });
+
+  it("submittedを提出済に変換する", () => {
+    expect(getStatusLabel("submitted")).toBe("提出済");
+  });
+
+  it("confirmedを確認済に変換する", () => {
+    expect(getStatusLabel("confirmed")).toBe("確認済");
+  });
+});
+
+describe("ReportsQuerySchema", () => {
+  it("正常なクエリパラメータをパースできる", () => {
+    const result = ReportsQuerySchema.parse({
+      date_from: "2024-01-01",
+      date_to: "2024-01-31",
+      sales_person_id: "1",
+      status: "submitted",
+      page: "1",
+      per_page: "20",
+      sort: "report_date",
+      order: "desc",
+    });
+
+    expect(result).toEqual({
+      date_from: "2024-01-01",
+      date_to: "2024-01-31",
+      sales_person_id: 1,
+      status: "submitted",
+      page: 1,
+      per_page: 20,
+      sort: "report_date",
+      order: "desc",
+    });
+  });
+
+  it("空のクエリパラメータでもデフォルト値が適用される", () => {
+    const result = ReportsQuerySchema.parse({});
+
+    expect(result).toEqual({
+      date_from: undefined,
+      date_to: undefined,
+      sales_person_id: undefined,
+      status: undefined,
+      page: 1,
+      per_page: 20,
+      sort: "report_date",
+      order: "desc",
+    });
+  });
+
+  it("不正なステータスはエラーになる", () => {
+    expect(() => {
+      ReportsQuerySchema.parse({
+        status: "invalid",
+      });
+    }).toThrow();
+  });
+
+  it("不正な日付形式はエラーになる", () => {
+    expect(() => {
+      ReportsQuerySchema.parse({
+        date_from: "2024/01/01",
+      });
+    }).toThrow();
+  });
+
+  it("sortがreport_dateまたはcreated_at以外はエラーになる", () => {
+    expect(() => {
+      ReportsQuerySchema.parse({
+        sort: "invalid_sort",
+      });
+    }).toThrow();
+  });
+});
+
+describe("VisitRecordSchema", () => {
+  it("正常な訪問記録をパースできる", () => {
+    const result = VisitRecordSchema.parse({
+      customer_id: 1,
+      visit_time: "10:30",
+      visit_purpose: "新製品のご提案",
+      visit_content: "新製品Xについて説明。担当者の佐藤様は興味を示された。",
+      visit_result: "次回デモ日程調整中",
+    });
+
+    expect(result).toEqual({
+      customer_id: 1,
+      visit_time: "10:30",
+      visit_purpose: "新製品のご提案",
+      visit_content: "新製品Xについて説明。担当者の佐藤様は興味を示された。",
+      visit_result: "次回デモ日程調整中",
+    });
+  });
+
+  it("必須項目のみでパースできる", () => {
+    const result = VisitRecordSchema.parse({
+      customer_id: 1,
+      visit_content: "訪問内容です。",
+    });
+
+    expect(result.customer_id).toBe(1);
+    expect(result.visit_content).toBe("訪問内容です。");
+    expect(result.visit_time).toBeUndefined();
+    expect(result.visit_purpose).toBeUndefined();
+    expect(result.visit_result).toBeUndefined();
+  });
+
+  it("customer_idが未指定の場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        visit_content: "訪問内容です。",
+      });
+    }).toThrow();
+  });
+
+  it("visit_contentが空の場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "",
+      });
+    }).toThrow();
+  });
+
+  it("visit_contentが1000文字を超える場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "あ".repeat(1001),
+      });
+    }).toThrow();
+  });
+
+  it("visit_purposeが100文字を超える場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_purpose: "あ".repeat(101),
+      });
+    }).toThrow();
+  });
+
+  it("visit_resultが200文字を超える場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_result: "あ".repeat(201),
+      });
+    }).toThrow();
+  });
+
+  it("visit_timeが不正な形式の場合はエラーになる", () => {
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_time: "10:00:00",
+      });
+    }).toThrow();
+
+    expect(() => {
+      VisitRecordSchema.parse({
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_time: "25:00",
+      });
+    }).toThrow();
+  });
+
+  it("visit_timeがnullの場合は許容される", () => {
+    const result = VisitRecordSchema.parse({
+      customer_id: 1,
+      visit_content: "訪問内容です。",
+      visit_time: null,
+    });
+
+    expect(result.visit_time).toBeNull();
+  });
+});
+
+describe("CreateReportSchema", () => {
+  it("正常なリクエストボディをパースできる", () => {
+    const yesterday = getYesterday();
+    const result = CreateReportSchema.parse({
+      report_date: yesterday,
+      problem: "課題・相談内容",
+      plan: "明日の予定",
+      status: "draft",
+      visits: [
+        {
+          customer_id: 1,
+          visit_time: "10:00",
+          visit_content: "訪問内容です。",
+        },
+      ],
+    });
+
+    expect(result.report_date).toBe(yesterday);
+    expect(result.problem).toBe("課題・相談内容");
+    expect(result.plan).toBe("明日の予定");
+    expect(result.status).toBe("draft");
+    expect(result.visits).toHaveLength(1);
+  });
+
+  it("下書き時は訪問記録なしでもパースできる", () => {
+    const yesterday = getYesterday();
+    const result = CreateReportSchema.parse({
+      report_date: yesterday,
+      status: "draft",
+    });
+
+    expect(result.visits).toEqual([]);
+  });
+
+  it("提出時に訪問記録がない場合はエラーになる", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: yesterday,
+        status: "submitted",
+        visits: [],
+      });
+    }).toThrow();
+  });
+
+  it("report_dateが未来日の場合はエラーになる", () => {
+    const tomorrow = getTomorrow();
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: tomorrow,
+        status: "draft",
+      });
+    }).toThrow();
+  });
+
+  it("report_dateが当日の場合はパースできる", () => {
+    const today = getToday();
+    const result = CreateReportSchema.parse({
+      report_date: today,
+      status: "draft",
+    });
+
+    expect(result.report_date).toBe(today);
+  });
+
+  it("problemが2000文字を超える場合はエラーになる", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: yesterday,
+        problem: "あ".repeat(2001),
+        status: "draft",
+      });
+    }).toThrow();
+  });
+
+  it("planが2000文字を超える場合はエラーになる", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: yesterday,
+        plan: "あ".repeat(2001),
+        status: "draft",
+      });
+    }).toThrow();
+  });
+
+  it("statusがconfirmedの場合はエラーになる（作成時はdraftまたはsubmittedのみ）", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: yesterday,
+        status: "confirmed",
+      });
+    }).toThrow();
+  });
+
+  it("report_dateが不正な形式の場合はエラーになる", () => {
+    expect(() => {
+      CreateReportSchema.parse({
+        report_date: "2024/01/15",
+        status: "draft",
+      });
+    }).toThrow();
+  });
+});
+
+describe("UpdateReportSchema", () => {
+  it("正常なリクエストボディをパースできる", () => {
+    const yesterday = getYesterday();
+    const result = UpdateReportSchema.parse({
+      report_date: yesterday,
+      problem: "更新された課題",
+      plan: "更新された予定",
+      status: "submitted",
+      visits: [
+        {
+          customer_id: 1,
+          visit_content: "訪問内容です。",
+        },
+      ],
+    });
+
+    expect(result.report_date).toBe(yesterday);
+    expect(result.status).toBe("submitted");
+    expect(result.visits).toHaveLength(1);
+  });
+
+  it("提出時に訪問記録がない場合はエラーになる", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      UpdateReportSchema.parse({
+        report_date: yesterday,
+        status: "submitted",
+        visits: [],
+      });
+    }).toThrow();
+  });
+
+  it("statusがconfirmedの場合はエラーになる", () => {
+    const yesterday = getYesterday();
+    expect(() => {
+      UpdateReportSchema.parse({
+        report_date: yesterday,
+        status: "confirmed",
+      });
+    }).toThrow();
+  });
+});
+
+describe("UpdateStatusSchema", () => {
+  it("draftをパースできる", () => {
+    const result = UpdateStatusSchema.parse({ status: "draft" });
+    expect(result.status).toBe("draft");
+  });
+
+  it("submittedをパースできる", () => {
+    const result = UpdateStatusSchema.parse({ status: "submitted" });
+    expect(result.status).toBe("submitted");
+  });
+
+  it("confirmedをパースできる", () => {
+    const result = UpdateStatusSchema.parse({ status: "confirmed" });
+    expect(result.status).toBe("confirmed");
+  });
+
+  it("不正なステータスはエラーになる", () => {
+    expect(() => {
+      UpdateStatusSchema.parse({ status: "invalid" });
+    }).toThrow();
+  });
+
+  it("statusが未指定の場合はエラーになる", () => {
+    expect(() => {
+      UpdateStatusSchema.parse({});
+    }).toThrow();
+  });
+});
+
+describe("ReportIdParamSchema", () => {
+  it("正常なIDをパースできる", () => {
+    const result = ReportIdParamSchema.parse({ id: "1" });
+    expect(result.id).toBe(1);
+  });
+
+  it("数値型のIDもパースできる", () => {
+    const result = ReportIdParamSchema.parse({ id: 5 });
+    expect(result.id).toBe(5);
+  });
+
+  it("0以下の値はエラーになる", () => {
+    expect(() => {
+      ReportIdParamSchema.parse({ id: "0" });
+    }).toThrow();
+  });
+
+  it("負の値はエラーになる", () => {
+    expect(() => {
+      ReportIdParamSchema.parse({ id: "-1" });
+    }).toThrow();
+  });
+
+  it("数値に変換できない文字列はエラーになる", () => {
+    expect(() => {
+      ReportIdParamSchema.parse({ id: "abc" });
+    }).toThrow();
+  });
+});

--- a/src/lib/api/schemas/report.ts
+++ b/src/lib/api/schemas/report.ts
@@ -1,0 +1,274 @@
+/**
+ * 日報APIのZodバリデーションスキーマ
+ */
+
+import { z } from "zod";
+
+import { CommonSchemas } from "../validation";
+
+/**
+ * ステータス定義
+ */
+export const ReportStatus = {
+  DRAFT: "draft",
+  SUBMITTED: "submitted",
+  CONFIRMED: "confirmed",
+} as const;
+
+export type ReportStatusType = (typeof ReportStatus)[keyof typeof ReportStatus];
+
+/**
+ * ステータスラベル変換
+ */
+export const StatusLabels: Record<ReportStatusType, string> = {
+  [ReportStatus.DRAFT]: "下書き",
+  [ReportStatus.SUBMITTED]: "提出済",
+  [ReportStatus.CONFIRMED]: "確認済",
+};
+
+/**
+ * ステータスをラベルに変換
+ */
+export function getStatusLabel(status: ReportStatusType): string {
+  return StatusLabels[status] || status;
+}
+
+/**
+ * 日報一覧取得用クエリパラメータスキーマ
+ */
+export const ReportsQuerySchema = z.object({
+  date_from: CommonSchemas.dateOnly.optional(),
+  date_to: CommonSchemas.dateOnly.optional(),
+  sales_person_id: z.coerce.number().int().positive().optional(),
+  status: z.enum(["draft", "submitted", "confirmed"]).optional(),
+  page: CommonSchemas.page,
+  per_page: CommonSchemas.perPage,
+  sort: z.enum(["report_date", "created_at"]).default("report_date"),
+  order: CommonSchemas.sortOrder,
+});
+
+export type ReportsQuery = z.infer<typeof ReportsQuerySchema>;
+
+/**
+ * 訪問記録スキーマ（作成・更新共通）
+ */
+export const VisitRecordSchema = z.object({
+  customer_id: z.number().int().positive("顧客を選択してください"),
+  visit_time: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "HH:MM形式で入力してください")
+    .nullable()
+    .optional(),
+  visit_purpose: z
+    .string()
+    .max(100, "訪問目的は100文字以内で入力してください")
+    .nullable()
+    .optional(),
+  visit_content: z
+    .string()
+    .min(1, "訪問内容は必須です")
+    .max(1000, "訪問内容は1000文字以内で入力してください"),
+  visit_result: z
+    .string()
+    .max(200, "訪問結果は200文字以内で入力してください")
+    .nullable()
+    .optional(),
+});
+
+export type VisitRecordInput = z.infer<typeof VisitRecordSchema>;
+
+/**
+ * 日報作成用リクエストボディスキーマ
+ */
+export const CreateReportSchema = z
+  .object({
+    report_date: CommonSchemas.dateOnly,
+    problem: z
+      .string()
+      .max(2000, "課題・相談は2000文字以内で入力してください")
+      .nullable()
+      .optional(),
+    plan: z
+      .string()
+      .max(2000, "明日の予定は2000文字以内で入力してください")
+      .nullable()
+      .optional(),
+    status: z.enum(["draft", "submitted"]),
+    visits: z.array(VisitRecordSchema).optional().default([]),
+  })
+  .superRefine((data, ctx) => {
+    // 報告日の未来日チェック
+    const reportDate = new Date(data.report_date);
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+
+    if (reportDate > today) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "報告日に未来日は指定できません",
+        path: ["report_date"],
+      });
+    }
+
+    // 提出時は訪問記録が必須
+    if (data.status === "submitted" && data.visits.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "提出時は訪問記録を1件以上登録してください",
+        path: ["visits"],
+      });
+    }
+  });
+
+export type CreateReportInput = z.infer<typeof CreateReportSchema>;
+
+/**
+ * 日報更新用リクエストボディスキーマ
+ */
+export const UpdateReportSchema = z
+  .object({
+    report_date: CommonSchemas.dateOnly,
+    problem: z
+      .string()
+      .max(2000, "課題・相談は2000文字以内で入力してください")
+      .nullable()
+      .optional(),
+    plan: z
+      .string()
+      .max(2000, "明日の予定は2000文字以内で入力してください")
+      .nullable()
+      .optional(),
+    status: z.enum(["draft", "submitted"]),
+    visits: z.array(VisitRecordSchema).optional().default([]),
+  })
+  .superRefine((data, ctx) => {
+    // 報告日の未来日チェック
+    const reportDate = new Date(data.report_date);
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+
+    if (reportDate > today) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "報告日に未来日は指定できません",
+        path: ["report_date"],
+      });
+    }
+
+    // 提出時は訪問記録が必須
+    if (data.status === "submitted" && data.visits.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "提出時は訪問記録を1件以上登録してください",
+        path: ["visits"],
+      });
+    }
+  });
+
+export type UpdateReportInput = z.infer<typeof UpdateReportSchema>;
+
+/**
+ * ステータス更新用リクエストボディスキーマ
+ */
+export const UpdateStatusSchema = z.object({
+  status: z.enum(["draft", "submitted", "confirmed"]),
+});
+
+export type UpdateStatusInput = z.infer<typeof UpdateStatusSchema>;
+
+/**
+ * 日報IDパスパラメータスキーマ
+ */
+export const ReportIdParamSchema = z.object({
+  id: CommonSchemas.positiveInt,
+});
+
+export type ReportIdParam = z.infer<typeof ReportIdParamSchema>;
+
+/**
+ * 訪問記録レスポンス型
+ */
+export interface VisitRecordResponse {
+  visit_id: number;
+  customer_id: number;
+  customer_name: string;
+  visit_time: string | null;
+  visit_purpose: string | null;
+  visit_content: string;
+  visit_result: string | null;
+}
+
+/**
+ * コメントレスポンス型
+ */
+export interface CommentResponse {
+  comment_id: number;
+  sales_person_id: number;
+  sales_person_name: string;
+  comment_text: string;
+  created_at: string;
+}
+
+/**
+ * 日報一覧アイテムレスポンス型
+ */
+export interface ReportListItem {
+  report_id: number;
+  report_date: string;
+  sales_person_id: number;
+  sales_person_name: string;
+  status: ReportStatusType;
+  status_label: string;
+  visit_count: number;
+  comment_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 日報詳細レスポンス型
+ */
+export interface ReportDetailResponse {
+  report_id: number;
+  report_date: string;
+  sales_person_id: number;
+  sales_person_name: string;
+  status: ReportStatusType;
+  status_label: string;
+  problem: string | null;
+  plan: string | null;
+  visits: VisitRecordResponse[];
+  comments: CommentResponse[];
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 日報作成レスポンス型
+ */
+export interface CreateReportResponse {
+  report_id: number;
+  report_date: string;
+  status: ReportStatusType;
+  created_at: string;
+}
+
+/**
+ * 日報更新レスポンス型
+ */
+export interface UpdateReportResponse {
+  report_id: number;
+  report_date: string;
+  status: ReportStatusType;
+  updated_at: string;
+}
+
+/**
+ * ステータス更新レスポンス型
+ */
+export interface UpdateStatusResponse {
+  report_id: number;
+  status: ReportStatusType;
+  status_label: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- 日報CRUD APIの実装
- GET /api/v1/reports - 日報一覧取得（ページネーション、フィルタリング対応）
- GET /api/v1/reports/{id} - 日報詳細取得（訪問記録、コメント含む）
- POST /api/v1/reports - 日報作成（訪問記録同時登録）
- PUT /api/v1/reports/{id} - 日報更新（確認済は編集不可）
- DELETE /api/v1/reports/{id} - 日報削除（下書きのみ、本人のみ）
- PATCH /api/v1/reports/{id}/status - ステータス更新（確認済は上長のみ）

## Test plan
- [ ] 日報一覧APIのフィルタリング機能確認
- [ ] 日報作成・更新時の訪問記録同時保存確認
- [ ] 権限に基づくアクセス制御確認（本人・上長・管理者）
- [ ] ステータス遷移ルールの確認
- [ ] テスト40件がすべてパスすることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)