### PR TITLE
feat: Issue #15 訪問記録API実装

### DIFF
--- a/src/app/api/v1/reports/[id]/visits/route.ts
+++ b/src/app/api/v1/reports/[id]/visits/route.ts
@@ -1,0 +1,231 @@
+/**
+ * 訪問記録API - 一覧取得・新規作成
+ *
+ * GET /api/v1/reports/{reportId}/visits - 一覧取得
+ * POST /api/v1/reports/{reportId}/visits - 新規作成
+ */
+
+import { auth } from "@/auth";
+import { createApiError, ErrorCode } from "@/lib/api/errors";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  createdResponse,
+  errorResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import {
+  CreateVisitSchema,
+  ReportIdParamSchema,
+} from "@/lib/api/schemas/visit";
+import { parseAndValidateBody, validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  CreateVisitResponse,
+  VisitRecordResponse,
+} from "@/lib/api/schemas/visit";
+
+/**
+ * 訪問時間をHH:MM形式に変換
+ */
+function formatVisitTime(date: Date | null): string | null {
+  if (!date) {
+    return null;
+  }
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * 訪問時間文字列をDate型に変換
+ * HH:MM形式の文字列を1970-01-01の時間として変換
+ */
+function parseVisitTime(timeStr: string | null | undefined): Date | null {
+  if (!timeStr) {
+    return null;
+  }
+
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  const date = new Date(1970, 0, 1, hours, minutes, 0);
+  return date;
+}
+
+/**
+ * ログインユーザーが日報にアクセス可能かチェック
+ * @returns true: アクセス可能, false: アクセス不可
+ */
+async function canAccessReport(
+  userId: number,
+  isManager: boolean,
+  reportOwnerId: number
+): Promise<boolean> {
+  // 自分の日報なら常にアクセス可能
+  if (userId === reportOwnerId) {
+    return true;
+  }
+
+  // 上長でない場合はアクセス不可
+  if (!isManager) {
+    return false;
+  }
+
+  // 上長の場合、部下の日報かどうかチェック
+  const subordinate = await prisma.salesPerson.findFirst({
+    where: {
+      id: reportOwnerId,
+      managerId: userId,
+    },
+  });
+
+  return subordinate !== null;
+}
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * GET /api/v1/reports/{reportId}/visits
+   * 指定した日報の訪問記録一覧を取得
+   */
+  GET: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: reportId } = validatePathParams(params, ReportIdParamSchema);
+
+    // 日報の存在チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: { salesPersonId: true },
+    });
+
+    if (!report) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // アクセス権限チェック
+    const canAccess = await canAccessReport(
+      session.user.id,
+      session.user.isManager,
+      report.salesPersonId
+    );
+
+    if (!canAccess) {
+      return forbiddenResponse("この日報の訪問記録を閲覧する権限がありません");
+    }
+
+    // 訪問記録を取得
+    const visitRecords = await prisma.visitRecord.findMany({
+      where: { reportId },
+      include: {
+        customer: {
+          select: { customerName: true },
+        },
+      },
+      orderBy: { visitTime: "asc" },
+    });
+
+    const items: VisitRecordResponse[] = visitRecords.map((v) => ({
+      visit_id: v.id,
+      customer_id: v.customerId,
+      customer_name: v.customer.customerName,
+      visit_time: formatVisitTime(v.visitTime),
+      visit_purpose: v.visitPurpose,
+      visit_content: v.visitContent,
+      visit_result: v.visitResult,
+      created_at: v.createdAt.toISOString(),
+      updated_at: v.updatedAt.toISOString(),
+    }));
+
+    return successResponse({ items });
+  },
+
+  /**
+   * POST /api/v1/reports/{reportId}/visits
+   * 訪問記録を新規作成
+   */
+  POST: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: reportId } = validatePathParams(params, ReportIdParamSchema);
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, CreateVisitSchema);
+
+    // 日報の存在チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: { salesPersonId: true, status: true },
+    });
+
+    if (!report) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // 本人のみ編集可能
+    if (report.salesPersonId !== session.user.id) {
+      return forbiddenResponse("この日報に訪問記録を追加する権限がありません");
+    }
+
+    // 確認済の日報は編集不可
+    if (report.status === "confirmed") {
+      return errorResponse(
+        ErrorCode.FORBIDDEN_EDIT,
+        "確認済の日報には訪問記録を追加できません"
+      );
+    }
+
+    // 顧客の存在チェック
+    const customer = await prisma.customer.findUnique({
+      where: { id: body.customer_id },
+      select: { id: true, customerName: true },
+    });
+
+    if (!customer) {
+      throw createApiError.validationError("指定された顧客が存在しません", [
+        {
+          field: "customer_id",
+          message: `顧客ID ${body.customer_id} が存在しません`,
+        },
+      ]);
+    }
+
+    // 訪問記録を作成
+    const visitRecord = await prisma.visitRecord.create({
+      data: {
+        reportId,
+        customerId: body.customer_id,
+        visitTime: parseVisitTime(body.visit_time),
+        visitPurpose: body.visit_purpose ?? null,
+        visitContent: body.visit_content,
+        visitResult: body.visit_result ?? null,
+      },
+    });
+
+    const response: CreateVisitResponse = {
+      visit_id: visitRecord.id,
+      report_id: reportId,
+      customer_id: visitRecord.customerId,
+      customer_name: customer.customerName,
+      created_at: visitRecord.createdAt.toISOString(),
+    };
+
+    return createdResponse(response, "訪問記録を作成しました");
+  },
+});
+
+export const GET = handlers.GET!;
+export const POST = handlers.POST!;

--- a/src/app/api/v1/visits/[id]/route.ts
+++ b/src/app/api/v1/visits/[id]/route.ts
@@ -1,0 +1,177 @@
+/**
+ * 訪問記録API - 更新・削除
+ *
+ * PUT /api/v1/visits/{id} - 更新
+ * DELETE /api/v1/visits/{id} - 削除
+ */
+
+import { auth } from "@/auth";
+import { createApiError, ErrorCode } from "@/lib/api/errors";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  errorResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import { UpdateVisitSchema, VisitIdParamSchema } from "@/lib/api/schemas/visit";
+import { parseAndValidateBody, validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type { UpdateVisitResponse } from "@/lib/api/schemas/visit";
+
+/**
+ * 訪問時間文字列をDate型に変換
+ * HH:MM形式の文字列を1970-01-01の時間として変換
+ */
+function parseVisitTime(timeStr: string | null | undefined): Date | null {
+  if (!timeStr) {
+    return null;
+  }
+
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  const date = new Date(1970, 0, 1, hours, minutes, 0);
+  return date;
+}
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * PUT /api/v1/visits/{id}
+   * 訪問記録を更新
+   */
+  PUT: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: visitId } = validatePathParams(params, VisitIdParamSchema);
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, UpdateVisitSchema);
+
+    // 訪問記録の存在チェック（日報情報も取得）
+    const visitRecord = await prisma.visitRecord.findUnique({
+      where: { id: visitId },
+      include: {
+        dailyReport: {
+          select: { salesPersonId: true, status: true },
+        },
+      },
+    });
+
+    if (!visitRecord) {
+      return notFoundResponse("指定された訪問記録が見つかりません");
+    }
+
+    // 本人のみ編集可能
+    if (visitRecord.dailyReport.salesPersonId !== session.user.id) {
+      return forbiddenResponse("この訪問記録を編集する権限がありません");
+    }
+
+    // 確認済の日報は編集不可
+    if (visitRecord.dailyReport.status === "confirmed") {
+      return errorResponse(
+        ErrorCode.FORBIDDEN_EDIT,
+        "確認済の日報の訪問記録は編集できません"
+      );
+    }
+
+    // 顧客の存在チェック
+    const customer = await prisma.customer.findUnique({
+      where: { id: body.customer_id },
+      select: { id: true, customerName: true },
+    });
+
+    if (!customer) {
+      throw createApiError.validationError("指定された顧客が存在しません", [
+        {
+          field: "customer_id",
+          message: `顧客ID ${body.customer_id} が存在しません`,
+        },
+      ]);
+    }
+
+    // 訪問記録を更新
+    const updatedVisitRecord = await prisma.visitRecord.update({
+      where: { id: visitId },
+      data: {
+        customerId: body.customer_id,
+        visitTime: parseVisitTime(body.visit_time),
+        visitPurpose: body.visit_purpose ?? null,
+        visitContent: body.visit_content,
+        visitResult: body.visit_result ?? null,
+      },
+    });
+
+    const response: UpdateVisitResponse = {
+      visit_id: updatedVisitRecord.id,
+      report_id: updatedVisitRecord.reportId,
+      customer_id: updatedVisitRecord.customerId,
+      customer_name: customer.customerName,
+      updated_at: updatedVisitRecord.updatedAt.toISOString(),
+    };
+
+    return successResponse(response, { message: "訪問記録を更新しました" });
+  },
+
+  /**
+   * DELETE /api/v1/visits/{id}
+   * 訪問記録を削除
+   */
+  DELETE: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: visitId } = validatePathParams(params, VisitIdParamSchema);
+
+    // 訪問記録の存在チェック（日報情報も取得）
+    const visitRecord = await prisma.visitRecord.findUnique({
+      where: { id: visitId },
+      include: {
+        dailyReport: {
+          select: { salesPersonId: true, status: true },
+        },
+      },
+    });
+
+    if (!visitRecord) {
+      return notFoundResponse("指定された訪問記録が見つかりません");
+    }
+
+    // 本人のみ削除可能
+    if (visitRecord.dailyReport.salesPersonId !== session.user.id) {
+      return forbiddenResponse("この訪問記録を削除する権限がありません");
+    }
+
+    // 確認済の日報は編集不可
+    if (visitRecord.dailyReport.status === "confirmed") {
+      return errorResponse(
+        ErrorCode.FORBIDDEN_DELETE,
+        "確認済の日報の訪問記録は削除できません"
+      );
+    }
+
+    // 訪問記録を削除
+    await prisma.visitRecord.delete({
+      where: { id: visitId },
+    });
+
+    return successResponse(
+      { visit_id: visitId },
+      { message: "訪問記録を削除しました" }
+    );
+  },
+});
+
+export const PUT = handlers.PUT!;
+export const DELETE = handlers.DELETE!;

--- a/src/lib/api/schemas/visit.test.ts
+++ b/src/lib/api/schemas/visit.test.ts
@@ -1,0 +1,361 @@
+/**
+ * 訪問記録APIスキーマのテスト
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  CreateVisitSchema,
+  ReportIdParamSchema,
+  UpdateVisitSchema,
+  VisitIdParamSchema,
+  VisitTimeSchema,
+} from "./visit";
+
+describe("VisitTimeSchema", () => {
+  describe("正常系", () => {
+    it("有効な時間形式をパースできる", () => {
+      const validTimes = ["00:00", "09:30", "12:00", "23:59"];
+
+      for (const time of validTimes) {
+        const result = VisitTimeSchema.parse(time);
+        expect(result).toBe(time);
+      }
+    });
+
+    it("nullを許容する", () => {
+      const result = VisitTimeSchema.parse(null);
+      expect(result).toBeNull();
+    });
+
+    it("undefinedを許容する", () => {
+      const result = VisitTimeSchema.parse(undefined);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("異常系", () => {
+    it("24時以上の時間はエラーになる", () => {
+      expect(() => VisitTimeSchema.parse("24:00")).toThrow();
+      expect(() => VisitTimeSchema.parse("25:00")).toThrow();
+    });
+
+    it("60分以上はエラーになる", () => {
+      expect(() => VisitTimeSchema.parse("10:60")).toThrow();
+      expect(() => VisitTimeSchema.parse("10:99")).toThrow();
+    });
+
+    it("不正な形式はエラーになる", () => {
+      expect(() => VisitTimeSchema.parse("10:00:00")).toThrow(); // 秒付き
+      expect(() => VisitTimeSchema.parse("10")).toThrow(); // 時のみ
+      expect(() => VisitTimeSchema.parse("10:5")).toThrow(); // 分が1桁
+      expect(() => VisitTimeSchema.parse("1:05")).toThrow(); // 時が1桁
+      expect(() => VisitTimeSchema.parse("ten:thirty")).toThrow(); // 文字列
+      expect(() => VisitTimeSchema.parse("")).toThrow(); // 空文字
+    });
+  });
+});
+
+describe("CreateVisitSchema", () => {
+  describe("正常系", () => {
+    it("すべてのフィールドを含む正常なリクエストをパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_time: "10:30",
+        visit_purpose: "新製品のご提案",
+        visit_content: "新製品Xについて説明。担当者の佐藤様は興味を示された。",
+        visit_result: "次回デモ日程調整中",
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result).toEqual(input);
+    });
+
+    it("必須項目のみでパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result.customer_id).toBe(1);
+      expect(result.visit_content).toBe("訪問内容です。");
+      expect(result.visit_time).toBeUndefined();
+      expect(result.visit_purpose).toBeUndefined();
+      expect(result.visit_result).toBeUndefined();
+    });
+
+    it("オプションフィールドがnullの場合もパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_time: null,
+        visit_purpose: null,
+        visit_content: "訪問内容です。",
+        visit_result: null,
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result.visit_time).toBeNull();
+      expect(result.visit_purpose).toBeNull();
+      expect(result.visit_result).toBeNull();
+    });
+
+    it("visit_contentが1000文字の境界値でパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "あ".repeat(1000),
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result.visit_content.length).toBe(1000);
+    });
+
+    it("visit_purposeが100文字の境界値でパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容",
+        visit_purpose: "あ".repeat(100),
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result.visit_purpose?.length).toBe(100);
+    });
+
+    it("visit_resultが200文字の境界値でパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容",
+        visit_result: "あ".repeat(200),
+      };
+
+      const result = CreateVisitSchema.parse(input);
+
+      expect(result.visit_result?.length).toBe(200);
+    });
+  });
+
+  describe("異常系", () => {
+    it("customer_idが未指定の場合はエラーになる", () => {
+      const input = {
+        visit_content: "訪問内容です。",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("customer_idが0の場合はエラーになる", () => {
+      const input = {
+        customer_id: 0,
+        visit_content: "訪問内容です。",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("customer_idが負の値の場合はエラーになる", () => {
+      const input = {
+        customer_id: -1,
+        visit_content: "訪問内容です。",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("customer_idが小数の場合はエラーになる", () => {
+      const input = {
+        customer_id: 1.5,
+        visit_content: "訪問内容です。",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_contentが未指定の場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_contentが空文字の場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_contentが1000文字を超える場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "あ".repeat(1001),
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_purposeが100文字を超える場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_purpose: "あ".repeat(101),
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_resultが200文字を超える場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_result: "あ".repeat(201),
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_timeが不正な形式の場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "訪問内容です。",
+        visit_time: "10:00:00",
+      };
+
+      expect(() => CreateVisitSchema.parse(input)).toThrow();
+    });
+  });
+});
+
+describe("UpdateVisitSchema", () => {
+  describe("正常系", () => {
+    it("すべてのフィールドを含む正常なリクエストをパースできる", () => {
+      const input = {
+        customer_id: 2,
+        visit_time: "14:00",
+        visit_purpose: "定期訪問",
+        visit_content: "定期フォローアップを実施。現状の課題をヒアリング。",
+        visit_result: "追加提案を検討",
+      };
+
+      const result = UpdateVisitSchema.parse(input);
+
+      expect(result).toEqual(input);
+    });
+
+    it("必須項目のみでパースできる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "更新された訪問内容です。",
+      };
+
+      const result = UpdateVisitSchema.parse(input);
+
+      expect(result.customer_id).toBe(1);
+      expect(result.visit_content).toBe("更新された訪問内容です。");
+    });
+  });
+
+  describe("異常系", () => {
+    it("customer_idが未指定の場合はエラーになる", () => {
+      const input = {
+        visit_content: "訪問内容です。",
+      };
+
+      expect(() => UpdateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_contentが空文字の場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "",
+      };
+
+      expect(() => UpdateVisitSchema.parse(input)).toThrow();
+    });
+
+    it("visit_contentが1000文字を超える場合はエラーになる", () => {
+      const input = {
+        customer_id: 1,
+        visit_content: "あ".repeat(1001),
+      };
+
+      expect(() => UpdateVisitSchema.parse(input)).toThrow();
+    });
+  });
+});
+
+describe("VisitIdParamSchema", () => {
+  describe("正常系", () => {
+    it("文字列のIDをパースできる", () => {
+      const result = VisitIdParamSchema.parse({ id: "1" });
+      expect(result.id).toBe(1);
+    });
+
+    it("数値のIDをパースできる", () => {
+      const result = VisitIdParamSchema.parse({ id: 5 });
+      expect(result.id).toBe(5);
+    });
+
+    it("大きな数値のIDをパースできる", () => {
+      const result = VisitIdParamSchema.parse({ id: "999999" });
+      expect(result.id).toBe(999999);
+    });
+  });
+
+  describe("異常系", () => {
+    it("0はエラーになる", () => {
+      expect(() => VisitIdParamSchema.parse({ id: "0" })).toThrow();
+    });
+
+    it("負の値はエラーになる", () => {
+      expect(() => VisitIdParamSchema.parse({ id: "-1" })).toThrow();
+    });
+
+    it("小数はエラーになる", () => {
+      expect(() => VisitIdParamSchema.parse({ id: "1.5" })).toThrow();
+    });
+
+    it("数値に変換できない文字列はエラーになる", () => {
+      expect(() => VisitIdParamSchema.parse({ id: "abc" })).toThrow();
+    });
+
+    it("idが未指定の場合はエラーになる", () => {
+      expect(() => VisitIdParamSchema.parse({})).toThrow();
+    });
+  });
+});
+
+describe("ReportIdParamSchema", () => {
+  describe("正常系", () => {
+    it("文字列のIDをパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: "10" });
+      expect(result.id).toBe(10);
+    });
+
+    it("数値のIDをパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: 20 });
+      expect(result.id).toBe(20);
+    });
+  });
+
+  describe("異常系", () => {
+    it("0はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "0" })).toThrow();
+    });
+
+    it("負の値はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "-5" })).toThrow();
+    });
+
+    it("数値に変換できない文字列はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "invalid" })).toThrow();
+    });
+  });
+});

--- a/src/lib/api/schemas/visit.ts
+++ b/src/lib/api/schemas/visit.ts
@@ -1,0 +1,123 @@
+/**
+ * 訪問記録APIのZodバリデーションスキーマ
+ *
+ * 訪問記録の作成・更新時のバリデーションルールを定義
+ */
+
+import { z } from "zod";
+
+import { CommonSchemas } from "../validation";
+
+/**
+ * 訪問時間のバリデーションスキーマ
+ * HH:MM形式（00:00-23:59）
+ */
+export const VisitTimeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "HH:MM形式で入力してください")
+  .nullable()
+  .optional();
+
+/**
+ * 訪問記録作成用リクエストボディスキーマ
+ */
+export const CreateVisitSchema = z.object({
+  customer_id: z.number().int().positive("顧客を選択してください"),
+  visit_time: VisitTimeSchema,
+  visit_purpose: z
+    .string()
+    .max(100, "訪問目的は100文字以内で入力してください")
+    .nullable()
+    .optional(),
+  visit_content: z
+    .string()
+    .min(1, "訪問内容は必須です")
+    .max(1000, "訪問内容は1000文字以内で入力してください"),
+  visit_result: z
+    .string()
+    .max(200, "訪問結果は200文字以内で入力してください")
+    .nullable()
+    .optional(),
+});
+
+export type CreateVisitInput = z.infer<typeof CreateVisitSchema>;
+
+/**
+ * 訪問記録更新用リクエストボディスキーマ
+ * 作成スキーマと同じだが、将来的に部分更新に対応できるよう分離
+ */
+export const UpdateVisitSchema = z.object({
+  customer_id: z.number().int().positive("顧客を選択してください"),
+  visit_time: VisitTimeSchema,
+  visit_purpose: z
+    .string()
+    .max(100, "訪問目的は100文字以内で入力してください")
+    .nullable()
+    .optional(),
+  visit_content: z
+    .string()
+    .min(1, "訪問内容は必須です")
+    .max(1000, "訪問内容は1000文字以内で入力してください"),
+  visit_result: z
+    .string()
+    .max(200, "訪問結果は200文字以内で入力してください")
+    .nullable()
+    .optional(),
+});
+
+export type UpdateVisitInput = z.infer<typeof UpdateVisitSchema>;
+
+/**
+ * 訪問記録IDパスパラメータスキーマ
+ */
+export const VisitIdParamSchema = z.object({
+  id: CommonSchemas.positiveInt,
+});
+
+export type VisitIdParam = z.infer<typeof VisitIdParamSchema>;
+
+/**
+ * 日報IDパスパラメータスキーマ（訪問記録API用）
+ */
+export const ReportIdParamSchema = z.object({
+  id: CommonSchemas.positiveInt,
+});
+
+export type ReportIdParam = z.infer<typeof ReportIdParamSchema>;
+
+/**
+ * 訪問記録レスポンス型
+ */
+export interface VisitRecordResponse {
+  visit_id: number;
+  customer_id: number;
+  customer_name: string;
+  visit_time: string | null;
+  visit_purpose: string | null;
+  visit_content: string;
+  visit_result: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 訪問記録作成レスポンス型
+ */
+export interface CreateVisitResponse {
+  visit_id: number;
+  report_id: number;
+  customer_id: number;
+  customer_name: string;
+  created_at: string;
+}
+
+/**
+ * 訪問記録更新レスポンス型
+ */
+export interface UpdateVisitResponse {
+  visit_id: number;
+  report_id: number;
+  customer_id: number;
+  customer_name: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- 訪問記録CRUD APIの実装
- GET /api/v1/reports/{reportId}/visits - 一覧取得
- POST /api/v1/reports/{reportId}/visits - 訪問記録作成
- PUT /api/v1/visits/{id} - 訪問記録更新
- DELETE /api/v1/visits/{id} - 訪問記録削除

## 権限チェック
- 日報作成者のみ訪問記録を編集・削除可能
- 確認済（confirmed）の日報は編集不可
- 閲覧は自分の日報または上長として部下の日報

## Test plan
- [ ] 訪問記録一覧取得APIの動作確認
- [ ] 訪問記録作成APIの動作確認
- [ ] 訪問記録更新APIの動作確認
- [ ] 訪問記録削除APIの動作確認
- [ ] 権限チェックの動作確認
- [ ] テスト40件がすべてパスすることを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)