### PR TITLE
feat: Issue #16 コメントAPI実装

### DIFF
--- a/src/app/api/v1/comments/[id]/route.ts
+++ b/src/app/api/v1/comments/[id]/route.ts
@@ -1,0 +1,70 @@
+/**
+ * コメントAPI - 削除
+ *
+ * DELETE /api/v1/comments/{id} - 削除
+ */
+
+import { auth } from "@/auth";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import { CommentIdParamSchema } from "@/lib/api/schemas/comment";
+import { validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type { DeleteCommentResponse } from "@/lib/api/schemas/comment";
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * DELETE /api/v1/comments/{id}
+   * コメントを削除
+   *
+   * 権限: 投稿者本人のみ削除可能
+   */
+  DELETE: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: commentId } = validatePathParams(params, CommentIdParamSchema);
+
+    // コメントの存在チェック
+    const comment = await prisma.comment.findUnique({
+      where: { id: commentId },
+      select: {
+        id: true,
+        salesPersonId: true,
+      },
+    });
+
+    if (!comment) {
+      return notFoundResponse("指定されたコメントが見つかりません");
+    }
+
+    // 投稿者本人のみ削除可能
+    if (comment.salesPersonId !== session.user.id) {
+      return forbiddenResponse("自分が投稿したコメントのみ削除できます");
+    }
+
+    // コメントを削除
+    await prisma.comment.delete({
+      where: { id: commentId },
+    });
+
+    const response: DeleteCommentResponse = {
+      comment_id: commentId,
+    };
+
+    return successResponse(response, { message: "コメントを削除しました" });
+  },
+});
+
+export const DELETE = handlers.DELETE!;

--- a/src/app/api/v1/reports/[id]/comments/route.ts
+++ b/src/app/api/v1/reports/[id]/comments/route.ts
@@ -1,0 +1,186 @@
+/**
+ * コメントAPI - 一覧取得・新規作成
+ *
+ * GET /api/v1/reports/{reportId}/comments - 一覧取得
+ * POST /api/v1/reports/{reportId}/comments - 新規作成
+ */
+
+import { auth } from "@/auth";
+import { createHandlers } from "@/lib/api/handler";
+import {
+  createdResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  successResponse,
+  unauthorizedResponse,
+} from "@/lib/api/response";
+import {
+  CreateCommentSchema,
+  ReportIdParamSchema,
+} from "@/lib/api/schemas/comment";
+import { parseAndValidateBody, validatePathParams } from "@/lib/api/validation";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  CommentResponse,
+  CreateCommentResponse,
+} from "@/lib/api/schemas/comment";
+
+/**
+ * ログインユーザーが日報にアクセス可能かチェック
+ * @returns true: アクセス可能, false: アクセス不可
+ */
+async function canAccessReport(
+  userId: number,
+  isManager: boolean,
+  reportOwnerId: number
+): Promise<boolean> {
+  // 自分の日報なら常にアクセス可能
+  if (userId === reportOwnerId) {
+    return true;
+  }
+
+  // 上長でない場合はアクセス不可
+  if (!isManager) {
+    return false;
+  }
+
+  // 上長の場合、部下の日報かどうかチェック
+  const subordinate = await prisma.salesPerson.findFirst({
+    where: {
+      id: reportOwnerId,
+      managerId: userId,
+    },
+  });
+
+  return subordinate !== null;
+}
+
+const handlers = createHandlers<{ id: string }>({
+  /**
+   * GET /api/v1/reports/{reportId}/comments
+   * 指定した日報のコメント一覧を取得
+   */
+  GET: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: reportId } = validatePathParams(params, ReportIdParamSchema);
+
+    // 日報の存在チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: { salesPersonId: true },
+    });
+
+    if (!report) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // アクセス権限チェック
+    const canAccess = await canAccessReport(
+      session.user.id,
+      session.user.isManager,
+      report.salesPersonId
+    );
+
+    if (!canAccess) {
+      return forbiddenResponse("この日報のコメントを閲覧する権限がありません");
+    }
+
+    // コメントを取得
+    const comments = await prisma.comment.findMany({
+      where: { reportId },
+      include: {
+        salesPerson: {
+          select: { name: true },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const items: CommentResponse[] = comments.map((c) => ({
+      comment_id: c.id,
+      report_id: c.reportId,
+      sales_person_id: c.salesPersonId,
+      sales_person_name: c.salesPerson.name,
+      comment_text: c.commentText,
+      created_at: c.createdAt.toISOString(),
+      updated_at: c.updatedAt.toISOString(),
+    }));
+
+    return successResponse({ items });
+  },
+
+  /**
+   * POST /api/v1/reports/{reportId}/comments
+   * コメントを新規作成
+   *
+   * 権限: 上長（isManager=true）のみ投稿可能
+   */
+  POST: async (request, context) => {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user) {
+      return unauthorizedResponse();
+    }
+
+    // 上長のみコメント投稿可能
+    if (!session.user.isManager) {
+      return forbiddenResponse("コメントを投稿できるのは上長のみです");
+    }
+
+    // パスパラメータのバリデーション
+    const params = await context.params;
+    const { id: reportId } = validatePathParams(params, ReportIdParamSchema);
+
+    // リクエストボディのバリデーション
+    const body = await parseAndValidateBody(request, CreateCommentSchema);
+
+    // 日報の存在チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: { salesPersonId: true },
+    });
+
+    if (!report) {
+      return notFoundResponse("指定された日報が見つかりません");
+    }
+
+    // アクセス権限チェック（自分または部下の日報のみコメント可能）
+    const canAccess = await canAccessReport(
+      session.user.id,
+      session.user.isManager,
+      report.salesPersonId
+    );
+
+    if (!canAccess) {
+      return forbiddenResponse("この日報にコメントする権限がありません");
+    }
+
+    // コメントを作成
+    const comment = await prisma.comment.create({
+      data: {
+        reportId,
+        salesPersonId: session.user.id,
+        commentText: body.comment_text,
+      },
+    });
+
+    const response: CreateCommentResponse = {
+      comment_id: comment.id,
+      report_id: reportId,
+      created_at: comment.createdAt.toISOString(),
+    };
+
+    return createdResponse(response, "コメントを投稿しました");
+  },
+});
+
+export const GET = handlers.GET!;
+export const POST = handlers.POST!;

--- a/src/lib/api/schemas/comment.test.ts
+++ b/src/lib/api/schemas/comment.test.ts
@@ -1,0 +1,278 @@
+/**
+ * コメントAPIスキーマのテスト
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  CreateCommentSchema,
+  CommentIdParamSchema,
+  ReportIdParamSchema,
+} from "./comment";
+
+describe("CreateCommentSchema", () => {
+  describe("正常系", () => {
+    it("有効なコメント内容をパースできる", () => {
+      const input = {
+        comment_text: "良い報告ですね。引き続きお願いします。",
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text).toBe(
+        "良い報告ですね。引き続きお願いします。"
+      );
+    });
+
+    it("1文字のコメント（最小境界値）をパースできる", () => {
+      const input = {
+        comment_text: "あ",
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text).toBe("あ");
+      expect(result.comment_text.length).toBe(1);
+    });
+
+    it("500文字のコメント（最大境界値）をパースできる", () => {
+      const input = {
+        comment_text: "あ".repeat(500),
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text.length).toBe(500);
+    });
+
+    it("英数字と記号を含むコメントをパースできる", () => {
+      const input = {
+        comment_text: "ABC123!@#$%^&*()_+-=[]{}|;':\",./<>?",
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text).toBe(input.comment_text);
+    });
+
+    it("改行を含むコメントをパースできる", () => {
+      const input = {
+        comment_text: "1行目\n2行目\n3行目",
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text).toBe("1行目\n2行目\n3行目");
+    });
+
+    it("スペースを含むコメントをパースできる", () => {
+      const input = {
+        comment_text: "  前後に  スペースを含む  コメント  ",
+      };
+
+      const result = CreateCommentSchema.parse(input);
+
+      expect(result.comment_text).toBe("  前後に  スペースを含む  コメント  ");
+    });
+  });
+
+  describe("異常系", () => {
+    it("comment_textが未指定の場合はエラーになる", () => {
+      const input = {};
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textが空文字の場合はエラーになる", () => {
+      const input = {
+        comment_text: "",
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textが501文字の場合はエラーになる", () => {
+      const input = {
+        comment_text: "あ".repeat(501),
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textが1000文字の場合はエラーになる", () => {
+      const input = {
+        comment_text: "あ".repeat(1000),
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textがnullの場合はエラーになる", () => {
+      const input = {
+        comment_text: null,
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textが数値の場合はエラーになる", () => {
+      const input = {
+        comment_text: 12345,
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textが配列の場合はエラーになる", () => {
+      const input = {
+        comment_text: ["コメント"],
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+
+    it("comment_textがオブジェクトの場合はエラーになる", () => {
+      const input = {
+        comment_text: { text: "コメント" },
+      };
+
+      expect(() => CreateCommentSchema.parse(input)).toThrow();
+    });
+  });
+
+  describe("エラーメッセージ", () => {
+    it("空文字の場合は「コメント内容は必須です」というエラーメッセージが返る", () => {
+      const input = {
+        comment_text: "",
+      };
+
+      const result = CreateCommentSchema.safeParse(input);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(1);
+        expect(result.error.issues[0]?.message).toBe("コメント内容は必須です");
+      }
+    });
+
+    it("501文字の場合は「コメント内容は500文字以内で入力してください」というエラーメッセージが返る", () => {
+      const input = {
+        comment_text: "あ".repeat(501),
+      };
+
+      const result = CreateCommentSchema.safeParse(input);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(1);
+        expect(result.error.issues[0]?.message).toBe(
+          "コメント内容は500文字以内で入力してください"
+        );
+      }
+    });
+  });
+});
+
+describe("CommentIdParamSchema", () => {
+  describe("正常系", () => {
+    it("文字列のIDをパースできる", () => {
+      const result = CommentIdParamSchema.parse({ id: "1" });
+      expect(result.id).toBe(1);
+    });
+
+    it("数値のIDをパースできる", () => {
+      const result = CommentIdParamSchema.parse({ id: 5 });
+      expect(result.id).toBe(5);
+    });
+
+    it("大きな数値のIDをパースできる", () => {
+      const result = CommentIdParamSchema.parse({ id: "999999" });
+      expect(result.id).toBe(999999);
+    });
+
+    it("1（最小有効値）をパースできる", () => {
+      const result = CommentIdParamSchema.parse({ id: "1" });
+      expect(result.id).toBe(1);
+    });
+  });
+
+  describe("異常系", () => {
+    it("0はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: "0" })).toThrow();
+    });
+
+    it("負の値はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: "-1" })).toThrow();
+    });
+
+    it("小数はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: "1.5" })).toThrow();
+    });
+
+    it("数値に変換できない文字列はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: "abc" })).toThrow();
+    });
+
+    it("idが未指定の場合はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({})).toThrow();
+    });
+
+    it("空文字はエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: "" })).toThrow();
+    });
+
+    it("nullはエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: null })).toThrow();
+    });
+
+    it("undefinedはエラーになる", () => {
+      expect(() => CommentIdParamSchema.parse({ id: undefined })).toThrow();
+    });
+  });
+});
+
+describe("ReportIdParamSchema", () => {
+  describe("正常系", () => {
+    it("文字列のIDをパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: "10" });
+      expect(result.id).toBe(10);
+    });
+
+    it("数値のIDをパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: 20 });
+      expect(result.id).toBe(20);
+    });
+
+    it("1（最小有効値）をパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: "1" });
+      expect(result.id).toBe(1);
+    });
+
+    it("大きな数値のIDをパースできる", () => {
+      const result = ReportIdParamSchema.parse({ id: "1000000" });
+      expect(result.id).toBe(1000000);
+    });
+  });
+
+  describe("異常系", () => {
+    it("0はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "0" })).toThrow();
+    });
+
+    it("負の値はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "-5" })).toThrow();
+    });
+
+    it("数値に変換できない文字列はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "invalid" })).toThrow();
+    });
+
+    it("小数はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({ id: "10.5" })).toThrow();
+    });
+
+    it("idが未指定の場合はエラーになる", () => {
+      expect(() => ReportIdParamSchema.parse({})).toThrow();
+    });
+  });
+});

--- a/src/lib/api/schemas/comment.ts
+++ b/src/lib/api/schemas/comment.ts
@@ -1,0 +1,71 @@
+/**
+ * コメントAPIのZodバリデーションスキーマ
+ *
+ * コメントの作成・削除時のバリデーションルールを定義
+ */
+
+import { z } from "zod";
+
+import { CommonSchemas } from "../validation";
+
+/**
+ * コメント作成用リクエストボディスキーマ
+ *
+ * バリデーションルール:
+ * - comment_text: 必須、1-500文字
+ */
+export const CreateCommentSchema = z.object({
+  comment_text: z
+    .string()
+    .min(1, "コメント内容は必須です")
+    .max(500, "コメント内容は500文字以内で入力してください"),
+});
+
+export type CreateCommentInput = z.infer<typeof CreateCommentSchema>;
+
+/**
+ * コメントIDパスパラメータスキーマ
+ */
+export const CommentIdParamSchema = z.object({
+  id: CommonSchemas.positiveInt,
+});
+
+export type CommentIdParam = z.infer<typeof CommentIdParamSchema>;
+
+/**
+ * 日報IDパスパラメータスキーマ（コメントAPI用）
+ */
+export const ReportIdParamSchema = z.object({
+  id: CommonSchemas.positiveInt,
+});
+
+export type ReportIdParam = z.infer<typeof ReportIdParamSchema>;
+
+/**
+ * コメントレスポンス型
+ */
+export interface CommentResponse {
+  comment_id: number;
+  report_id: number;
+  sales_person_id: number;
+  sales_person_name: string;
+  comment_text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * コメント作成レスポンス型
+ */
+export interface CreateCommentResponse {
+  comment_id: number;
+  report_id: number;
+  created_at: string;
+}
+
+/**
+ * コメント削除レスポンス型
+ */
+export interface DeleteCommentResponse {
+  comment_id: number;
+}


### PR DESCRIPTION
## Summary
- コメントCRUD APIの実装
- GET /api/v1/reports/{reportId}/comments - コメント一覧取得
- POST /api/v1/reports/{reportId}/comments - コメント作成（上長のみ）
- DELETE /api/v1/comments/{id} - コメント削除（投稿者本人のみ）

## 権限チェック
- 上長（isManager=true）のみコメント投稿可能
- 投稿者本人のみ自分のコメントを削除可能
- 閲覧は自分の日報または上長として部下の日報

## Test plan
- [ ] コメント一覧取得APIの動作確認
- [ ] コメント作成APIの動作確認（上長権限）
- [ ] コメント削除APIの動作確認（投稿者本人）
- [ ] 権限チェックの動作確認
- [ ] テスト37件がすべてパスすることを確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)