### PR TITLE
feat: Issue #13 日報作成・編集画面実装

### DIFF
--- a/src/app/reports/[id]/edit/page.tsx
+++ b/src/app/reports/[id]/edit/page.tsx
@@ -1,0 +1,187 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ReportForm } from "@/features/reports/components";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  ReportDetail,
+  VisitRecord,
+  Comment,
+} from "@/features/reports/types";
+import type { ReportStatusType } from "@/lib/api/schemas/report";
+
+interface EditReportPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "日報編集 | 営業日報システム",
+  description: "日報を編集します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+/**
+ * 訪問時間をHH:MM形式に変換
+ */
+function formatVisitTime(date: Date | null): string | null {
+  if (!date) {
+    return null;
+  }
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * 日報データを取得
+ */
+async function getReport(
+  reportId: number,
+  userId: number
+): Promise<ReportDetail | null> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    include: {
+      salesPerson: {
+        select: { name: true },
+      },
+      visitRecords: {
+        include: {
+          customer: {
+            select: { customerName: true },
+          },
+        },
+        orderBy: { visitTime: "asc" },
+      },
+      comments: {
+        include: {
+          salesPerson: {
+            select: { name: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!report) {
+    return null;
+  }
+
+  // 本人のみ編集可能
+  if (report.salesPersonId !== userId) {
+    return null;
+  }
+
+  const status = report.status as ReportStatusType;
+  const dateStr = report.reportDate.toISOString().split("T")[0];
+
+  const visits: VisitRecord[] = report.visitRecords.map((v) => ({
+    visit_id: v.id,
+    customer_id: v.customerId,
+    customer_name: v.customer.customerName,
+    visit_time: formatVisitTime(v.visitTime),
+    visit_purpose: v.visitPurpose,
+    visit_content: v.visitContent,
+    visit_result: v.visitResult,
+  }));
+
+  const comments: Comment[] = report.comments.map((c) => ({
+    comment_id: c.id,
+    sales_person_id: c.salesPersonId,
+    sales_person_name: c.salesPerson.name,
+    comment_text: c.commentText,
+    created_at: c.createdAt.toISOString(),
+  }));
+
+  const statusLabels: Record<ReportStatusType, string> = {
+    draft: "下書き",
+    submitted: "提出済",
+    confirmed: "確認済",
+  };
+
+  return {
+    report_id: report.id,
+    report_date: dateStr ?? "",
+    sales_person_id: report.salesPersonId,
+    sales_person_name: report.salesPerson.name,
+    status,
+    status_label: statusLabels[status],
+    problem: report.problem,
+    plan: report.plan,
+    visits,
+    comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  };
+}
+
+export default async function EditReportPage({ params }: EditReportPageProps) {
+  // 認証チェック
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  // パラメータを取得
+  const { id } = await params;
+  const reportId = parseInt(id, 10);
+
+  if (isNaN(reportId)) {
+    notFound();
+  }
+
+  // 日報データを取得
+  const report = await getReport(reportId, session.user.id);
+
+  if (!report) {
+    notFound();
+  }
+
+  // 確認済の日報は編集不可
+  if (report.status === "confirmed") {
+    return (
+      <AuthenticatedLayout>
+        <div className="space-y-6">
+          <div className="flex items-center gap-4">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/reports">
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                日報一覧に戻る
+              </Link>
+            </Button>
+          </div>
+          <h1 className="text-2xl font-bold">日報編集</h1>
+          <Alert variant="destructive">
+            <AlertDescription>確認済の日報は編集できません。</AlertDescription>
+          </Alert>
+        </div>
+      </AuthenticatedLayout>
+    );
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/reports">
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              日報一覧に戻る
+            </Link>
+          </Button>
+        </div>
+        <h1 className="text-2xl font-bold">日報編集</h1>
+        <ReportForm report={report} isEdit />
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -1,0 +1,33 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import { Button } from "@/components/ui/button";
+import { ReportForm } from "@/features/reports/components";
+
+export const metadata = {
+  title: "日報作成 | 営業日報システム",
+  description: "新しい日報を作成します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+export default function NewReportPage() {
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/reports">
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              日報一覧に戻る
+            </Link>
+          </Button>
+        </div>
+        <h1 className="text-2xl font-bold">日報作成</h1>
+        <ReportForm />
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/features/reports/api.ts
+++ b/src/features/reports/api.ts
@@ -1,14 +1,19 @@
 /**
- * 日報一覧API関数
+ * 日報API関数
  */
 
 import { REPORTS_API_BASE } from "./constants";
 
 import type {
   ApiErrorResponse,
+  CreateReportRequest,
+  CreateReportResponse,
+  CustomersOptionsResponse,
+  ReportDetailResponse,
   ReportsListResponse,
   ReportsSearchParams,
   SalesPersonsOptionsResponse,
+  UpdateReportResponse,
 } from "./types";
 
 /**
@@ -95,4 +100,89 @@ export async function fetchSelectableSalesPersons(): Promise<SalesPersonsOptions
       ),
     },
   };
+}
+
+/**
+ * 日報詳細を取得
+ */
+export async function fetchReportById(
+  reportId: number
+): Promise<ReportDetailResponse> {
+  const response = await fetch(`${REPORTS_API_BASE}/${reportId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "日報の取得に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * 日報を作成
+ */
+export async function createReport(
+  data: CreateReportRequest
+): Promise<CreateReportResponse> {
+  const response = await fetch(REPORTS_API_BASE, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "日報の作成に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * 日報を更新
+ */
+export async function updateReport(
+  reportId: number,
+  data: CreateReportRequest
+): Promise<UpdateReportResponse> {
+  const response = await fetch(`${REPORTS_API_BASE}/${reportId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "日報の更新に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * 顧客一覧を取得（選択肢用）
+ */
+export async function fetchCustomersForSelect(): Promise<CustomersOptionsResponse> {
+  const response = await fetch("/api/v1/customers?per_page=100", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "顧客一覧の取得に失敗しました");
+  }
+
+  return response.json();
 }

--- a/src/features/reports/components/ReportForm.test.tsx
+++ b/src/features/reports/components/ReportForm.test.tsx
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen, mockMemberUser, waitFor } from "@/test/test-utils";
+
+import { ReportForm } from "./ReportForm";
+
+import type { ReportDetail } from "../types";
+
+// next/navigation のモック
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/reports/new",
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+// API モック
+const mockFetchCustomersForSelect = vi.fn();
+const mockCreateReport = vi.fn();
+const mockUpdateReport = vi.fn();
+
+vi.mock("../api", () => ({
+  fetchCustomersForSelect: () => mockFetchCustomersForSelect(),
+  createReport: (data: unknown) => mockCreateReport(data),
+  updateReport: (id: number, data: unknown) => mockUpdateReport(id, data),
+}));
+
+const mockCustomers = [
+  { customer_id: 1, customer_name: "株式会社テスト" },
+  { customer_id: 2, customer_name: "サンプル商事" },
+];
+
+describe("ReportForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchCustomersForSelect.mockResolvedValue({
+      success: true,
+      data: {
+        items: mockCustomers,
+        pagination: { total: 2, per_page: 100, current_page: 1, last_page: 1 },
+      },
+    });
+    mockCreateReport.mockResolvedValue({
+      success: true,
+      data: { report_id: 1 },
+    });
+    mockUpdateReport.mockResolvedValue({
+      success: true,
+      data: { report_id: 1 },
+    });
+  });
+
+  describe("rendering - create mode", () => {
+    it("should render all form fields", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/報告日/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("訪問記録")).toBeInTheDocument();
+      expect(screen.getByLabelText(/課題・相談/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/明日の予定/)).toBeInTheDocument();
+    });
+
+    it("should show title for create mode", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(screen.getByText("日報作成")).toBeInTheDocument();
+      });
+    });
+
+    it("should show action buttons", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "下書き保存" })
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("button", { name: "提出" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "キャンセル" })
+      ).toBeInTheDocument();
+    });
+
+    it("should show add visit button", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /訪問を追加/ })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should show empty visits message initially", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(screen.getByText("訪問記録がありません")).toBeInTheDocument();
+      });
+    });
+
+    it("should set today's date as default", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        const dateInput = screen.getByLabelText(/報告日/) as HTMLInputElement;
+        expect(dateInput.value).toBeTruthy();
+      });
+    });
+  });
+
+  describe("rendering - edit mode", () => {
+    const mockReport: ReportDetail = {
+      report_id: 1,
+      report_date: "2024-01-15",
+      sales_person_id: 1,
+      sales_person_name: "テスト太郎",
+      status: "draft",
+      status_label: "下書き",
+      problem: "課題テスト",
+      plan: "予定テスト",
+      visits: [
+        {
+          visit_id: 1,
+          customer_id: 1,
+          customer_name: "株式会社テスト",
+          visit_time: "10:00",
+          visit_purpose: "商談",
+          visit_content: "新規提案を行いました",
+          visit_result: "次回アポイント取得",
+        },
+      ],
+      comments: [],
+      created_at: "2024-01-15T00:00:00Z",
+      updated_at: "2024-01-15T00:00:00Z",
+    };
+
+    it("should show title for edit mode", async () => {
+      render(<ReportForm report={mockReport} isEdit />, {
+        user: mockMemberUser,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("日報編集")).toBeInTheDocument();
+      });
+    });
+
+    it("should populate form with existing data", async () => {
+      render(<ReportForm report={mockReport} isEdit />, {
+        user: mockMemberUser,
+      });
+
+      await waitFor(() => {
+        const dateInput = screen.getByLabelText(/報告日/) as HTMLInputElement;
+        expect(dateInput.value).toBe("2024-01-15");
+      });
+
+      expect(screen.getByLabelText(/課題・相談/)).toHaveValue("課題テスト");
+      expect(screen.getByLabelText(/明日の予定/)).toHaveValue("予定テスト");
+    });
+
+    it("should show existing visit records", async () => {
+      render(<ReportForm report={mockReport} isEdit />, {
+        user: mockMemberUser,
+      });
+
+      await waitFor(() => {
+        // 既存の訪問記録がフォームに表示されていることを確認
+        expect(
+          screen.getByRole("group", { name: "訪問記録 1" })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("add visit functionality", () => {
+    it("should add visit record when clicking add button", async () => {
+      const { user } = render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /訪問を追加/ })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /訪問を追加/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("group", { name: "訪問記録 1" })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText("訪問記録がありません")
+      ).not.toBeInTheDocument();
+    });
+
+    it("should be able to add multiple visit records", async () => {
+      const { user } = render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /訪問を追加/ })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /訪問を追加/ }));
+      await user.click(screen.getByRole("button", { name: /訪問を追加/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("group", { name: "訪問記録 1" })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("group", { name: "訪問記録 2" })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("remove visit functionality", () => {
+    it("should remove visit record when clicking delete button", async () => {
+      const { user } = render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /訪問を追加/ })
+        ).toBeInTheDocument();
+      });
+
+      // 訪問記録を追加
+      await user.click(screen.getByRole("button", { name: /訪問を追加/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("group", { name: "訪問記録 1" })
+        ).toBeInTheDocument();
+      });
+
+      // 削除ボタンをクリック
+      await user.click(
+        screen.getByRole("button", { name: "訪問記録 1 を削除" })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("group", { name: "訪問記録 1" })
+        ).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText("訪問記録がありません")).toBeInTheDocument();
+    });
+  });
+
+  describe("customers loading", () => {
+    it("should load customers on mount", async () => {
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(mockFetchCustomersForSelect).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("should show loading state while loading customers", async () => {
+      // 遅延を追加
+      mockFetchCustomersForSelect.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  success: true,
+                  data: { items: mockCustomers, pagination: {} },
+                }),
+              100
+            )
+          )
+      );
+
+      render(<ReportForm />, { user: mockMemberUser });
+
+      expect(screen.getByText("顧客データを読み込み中...")).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("顧客データを読み込み中...")
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("should show error when customers loading fails", async () => {
+      mockFetchCustomersForSelect.mockRejectedValue(
+        new Error("ネットワークエラー")
+      );
+
+      render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("顧客一覧の取得に失敗しました")
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("form validation", () => {
+    it("should show validation error when submitting without visits", async () => {
+      const { user } = render(<ReportForm />, { user: mockMemberUser });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "提出" })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "提出" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/提出時は訪問記録を1件以上登録してください/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/features/reports/components/ReportForm.tsx
+++ b/src/features/reports/components/ReportForm.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+
+import { createReport, fetchCustomersForSelect, updateReport } from "../api";
+import {
+  convertFormToApiRequest,
+  getDefaultReportFormValues,
+  reportFormSchema,
+  validateForSubmission,
+  validateReportDate,
+} from "../schemas";
+import { VisitRecordList } from "./VisitRecordList";
+
+import type { ReportFormValues, VisitRecordFormValues } from "../schemas";
+import type { CustomerOption, ReportDetail } from "../types";
+
+interface ReportFormProps {
+  /** 編集モードの場合は既存の日報データ */
+  report?: ReportDetail;
+  /** 編集モードかどうか */
+  isEdit?: boolean;
+}
+
+/**
+ * 日報フォームコンポーネント
+ * 作成画面・編集画面共通で使用
+ */
+export function ReportForm({ report, isEdit = false }: ReportFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+  const [isLoadingCustomers, setIsLoadingCustomers] = useState(true);
+
+  // 既存データをフォーム形式に変換
+  const getInitialValues = (): ReportFormValues => {
+    if (!report) {
+      return getDefaultReportFormValues();
+    }
+
+    return {
+      report_date: report.report_date,
+      problem: report.problem ?? "",
+      plan: report.plan ?? "",
+      visits: report.visits.map(
+        (visit): VisitRecordFormValues => ({
+          customer_id: visit.customer_id.toString(),
+          visit_time: visit.visit_time ?? "",
+          visit_purpose: visit.visit_purpose ?? "",
+          visit_content: visit.visit_content,
+          visit_result: visit.visit_result ?? "",
+        })
+      ),
+    };
+  };
+
+  const form = useForm<ReportFormValues>({
+    resolver: zodResolver(reportFormSchema),
+    defaultValues: getInitialValues(),
+  });
+
+  // 顧客一覧を取得
+  useEffect(() => {
+    const loadCustomers = async () => {
+      try {
+        const response = await fetchCustomersForSelect();
+        setCustomers(
+          response.data.items.map((item) => ({
+            customer_id: item.customer_id,
+            customer_name: item.customer_name,
+          }))
+        );
+      } catch (err) {
+        console.error("顧客一覧の取得に失敗しました:", err);
+        setError("顧客一覧の取得に失敗しました");
+      } finally {
+        setIsLoadingCustomers(false);
+      }
+    };
+
+    loadCustomers();
+  }, []);
+
+  // 下書き保存
+  const handleSaveDraft = () => {
+    setError(null);
+
+    // 報告日のバリデーション
+    const reportDate = form.getValues("report_date");
+    const dateError = validateReportDate(reportDate);
+    if (dateError) {
+      setError(dateError);
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const values = form.getValues();
+        const apiData = convertFormToApiRequest(values, "draft");
+
+        if (isEdit && report) {
+          await updateReport(report.report_id, apiData);
+        } else {
+          await createReport(apiData);
+        }
+
+        router.push("/reports");
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "保存に失敗しました");
+      }
+    });
+  };
+
+  // 提出
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setError(null);
+
+    // 提出時のバリデーション
+    const validationErrors = validateForSubmission(values);
+    if (validationErrors.length > 0) {
+      setError(validationErrors.join("\n"));
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const apiData = convertFormToApiRequest(values, "submitted");
+
+        if (isEdit && report) {
+          await updateReport(report.report_id, apiData);
+        } else {
+          await createReport(apiData);
+        }
+
+        router.push("/reports");
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "提出に失敗しました");
+      }
+    });
+  });
+
+  const handleCancel = () => {
+    router.push("/reports");
+  };
+
+  // 今日の日付（最大値として使用）
+  const today = new Date().toISOString().split("T")[0];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{isEdit ? "日報編集" : "日報作成"}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <FormProvider {...form}>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="whitespace-pre-wrap">
+                  {error}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* 報告日 */}
+            <FormField
+              control={form.control}
+              name="report_date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    報告日 <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      max={today}
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Separator />
+
+            {/* 訪問記録 */}
+            {isLoadingCustomers ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <span className="ml-2 text-muted-foreground">
+                  顧客データを読み込み中...
+                </span>
+              </div>
+            ) : (
+              <VisitRecordList customers={customers} disabled={isPending} />
+            )}
+
+            <Separator />
+
+            {/* 課題・相談 */}
+            <FormField
+              control={form.control}
+              name="problem"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>課題・相談</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="課題や相談事項があれば入力してください（最大2000文字）"
+                      rows={4}
+                      maxLength={2000}
+                      disabled={isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 明日の予定 */}
+            <FormField
+              control={form.control}
+              name="plan"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>明日の予定</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="明日の予定を入力してください（最大2000文字）"
+                      rows={4}
+                      maxLength={2000}
+                      disabled={isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* ボタンエリア */}
+            <div className="flex flex-col gap-4 pt-4 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isPending}
+                asChild
+              >
+                <Link href="/reports">キャンセル</Link>
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleSaveDraft}
+                disabled={isPending || isLoadingCustomers}
+              >
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                下書き保存
+              </Button>
+              <Button type="submit" disabled={isPending || isLoadingCustomers}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                提出
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reports/components/VisitRecordItem.tsx
+++ b/src/features/reports/components/VisitRecordItem.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { ReportFormValues } from "../schemas";
+import type { CustomerOption } from "../types";
+
+interface VisitRecordItemProps {
+  /** 配列内のインデックス */
+  index: number;
+  /** 顧客選択肢 */
+  customers: CustomerOption[];
+  /** 削除コールバック */
+  onRemove: () => void;
+  /** フォームが無効かどうか */
+  disabled?: boolean;
+}
+
+/**
+ * 訪問記録入力項目コンポーネント
+ */
+export function VisitRecordItem({
+  index,
+  customers,
+  onRemove,
+  disabled = false,
+}: VisitRecordItemProps) {
+  const { control } = useFormContext<ReportFormValues>();
+
+  return (
+    <div
+      className="relative rounded-lg border bg-muted/30 p-4"
+      role="group"
+      aria-label={`訪問記録 ${index + 1}`}
+    >
+      {/* 削除ボタン */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-2 top-2 h-8 w-8 text-muted-foreground hover:text-destructive"
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label={`訪問記録 ${index + 1} を削除`}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+
+      <div className="grid gap-4">
+        {/* 1行目: 顧客名、訪問時間 */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={control}
+            name={`visits.${index}.customer_id`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  顧客名 <span className="text-destructive">*</span>
+                </FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  disabled={disabled}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="顧客を選択してください" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {customers.map((customer) => (
+                      <SelectItem
+                        key={customer.customer_id}
+                        value={customer.customer_id.toString()}
+                      >
+                        {customer.customer_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`visits.${index}.visit_time`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>訪問時間</FormLabel>
+                <FormControl>
+                  <Input
+                    type="time"
+                    disabled={disabled}
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* 2行目: 訪問目的 */}
+        <FormField
+          control={control}
+          name={`visits.${index}.visit_purpose`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>訪問目的</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="訪問目的を入力してください（最大100文字）"
+                  maxLength={100}
+                  disabled={disabled}
+                  {...field}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 3行目: 訪問内容 */}
+        <FormField
+          control={control}
+          name={`visits.${index}.visit_content`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                訪問内容 <span className="text-destructive">*</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="訪問内容を入力してください（最大1000文字）"
+                  rows={3}
+                  maxLength={1000}
+                  disabled={disabled}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 4行目: 訪問結果 */}
+        <FormField
+          control={control}
+          name={`visits.${index}.visit_result`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>訪問結果</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="訪問結果を入力してください（最大200文字）"
+                  maxLength={200}
+                  disabled={disabled}
+                  {...field}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/reports/components/VisitRecordList.tsx
+++ b/src/features/reports/components/VisitRecordList.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+
+import { getDefaultVisitRecordValues } from "../schemas";
+import { VisitRecordItem } from "./VisitRecordItem";
+
+import type { ReportFormValues } from "../schemas";
+import type { CustomerOption } from "../types";
+
+interface VisitRecordListProps {
+  /** 顧客選択肢 */
+  customers: CustomerOption[];
+  /** フォームが無効かどうか */
+  disabled?: boolean;
+}
+
+/**
+ * 訪問記録リストコンポーネント
+ * useFieldArrayを使用して動的に訪問記録を追加・削除する
+ */
+export function VisitRecordList({
+  customers,
+  disabled = false,
+}: VisitRecordListProps) {
+  const { control, formState } = useFormContext<ReportFormValues>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "visits",
+  });
+
+  const handleAddVisit = () => {
+    append(getDefaultVisitRecordValues());
+  };
+
+  // visitsフィールドのエラーを取得
+  const visitsError = formState.errors.visits;
+  const hasArrayError =
+    visitsError && !Array.isArray(visitsError) && visitsError.message;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">訪問記録</h3>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAddVisit}
+          disabled={disabled}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          訪問を追加
+        </Button>
+      </div>
+
+      {/* 訪問記録が0件の場合のメッセージ */}
+      {fields.length === 0 && (
+        <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+          <p>訪問記録がありません</p>
+          <p className="text-sm">
+            「訪問を追加」ボタンをクリックして訪問記録を追加してください
+          </p>
+        </div>
+      )}
+
+      {/* 配列レベルのエラー表示 */}
+      {hasArrayError && (
+        <p className="text-sm text-destructive" role="alert">
+          {visitsError.message}
+        </p>
+      )}
+
+      {/* 訪問記録リスト */}
+      <div className="space-y-4">
+        {fields.map((field, index) => (
+          <VisitRecordItem
+            key={field.id}
+            index={index}
+            customers={customers}
+            onRemove={() => remove(index)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/reports/components/index.ts
+++ b/src/features/reports/components/index.ts
@@ -1,5 +1,8 @@
+export { ReportForm } from "./ReportForm";
 export { ReportsList } from "./ReportsList";
 export { ReportsListSkeleton } from "./ReportsListSkeleton";
 export { ReportsSearchForm } from "./ReportsSearchForm";
 export { ReportsTable } from "./ReportsTable";
 export { ReportStatusBadge } from "./ReportStatusBadge";
+export { VisitRecordItem } from "./VisitRecordItem";
+export { VisitRecordList } from "./VisitRecordList";

--- a/src/features/reports/schemas.test.ts
+++ b/src/features/reports/schemas.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  visitRecordFormSchema,
+  reportFormSchema,
+  getDefaultReportFormValues,
+  getDefaultVisitRecordValues,
+  validateReportDate,
+  validateForSubmission,
+  convertFormToApiRequest,
+} from "./schemas";
+
+describe("visitRecordFormSchema", () => {
+  describe("customer_id validation", () => {
+    it("should fail when customer_id is empty", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "",
+        visit_content: "テスト訪問内容",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("顧客を選択してください");
+      }
+    });
+
+    it("should pass with valid customer_id", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "テスト訪問内容",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("visit_content validation", () => {
+    it("should fail when visit_content is empty", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const visitContentError = result.error.issues.find(
+          (issue) => issue.path[0] === "visit_content"
+        );
+        expect(visitContentError?.message).toBe("訪問内容は必須です");
+      }
+    });
+
+    it("should fail when visit_content exceeds 1000 characters", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "あ".repeat(1001),
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "訪問内容は1000文字以内で入力してください"
+        );
+      }
+    });
+
+    it("should pass with valid visit_content", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "テスト訪問内容",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("visit_purpose validation", () => {
+    it("should fail when visit_purpose exceeds 100 characters", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "テスト訪問内容",
+        visit_purpose: "あ".repeat(101),
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const visitPurposeError = result.error.issues.find(
+          (issue) => issue.path[0] === "visit_purpose"
+        );
+        expect(visitPurposeError?.message).toBe(
+          "訪問目的は100文字以内で入力してください"
+        );
+      }
+    });
+
+    it("should pass with empty visit_purpose", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "テスト訪問内容",
+        visit_purpose: "",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("visit_result validation", () => {
+    it("should fail when visit_result exceeds 200 characters", () => {
+      const result = visitRecordFormSchema.safeParse({
+        customer_id: "1",
+        visit_content: "テスト訪問内容",
+        visit_result: "あ".repeat(201),
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const visitResultError = result.error.issues.find(
+          (issue) => issue.path[0] === "visit_result"
+        );
+        expect(visitResultError?.message).toBe(
+          "訪問結果は200文字以内で入力してください"
+        );
+      }
+    });
+  });
+});
+
+describe("reportFormSchema", () => {
+  describe("report_date validation", () => {
+    it("should fail when report_date is empty", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "",
+        visits: [],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("報告日は必須です");
+      }
+    });
+
+    it("should pass with valid report_date", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "2024-01-15",
+        visits: [],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("problem validation", () => {
+    it("should fail when problem exceeds 2000 characters", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "2024-01-15",
+        problem: "あ".repeat(2001),
+        visits: [],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const problemError = result.error.issues.find(
+          (issue) => issue.path[0] === "problem"
+        );
+        expect(problemError?.message).toBe(
+          "課題・相談は2000文字以内で入力してください"
+        );
+      }
+    });
+  });
+
+  describe("plan validation", () => {
+    it("should fail when plan exceeds 2000 characters", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "2024-01-15",
+        plan: "あ".repeat(2001),
+        visits: [],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const planError = result.error.issues.find(
+          (issue) => issue.path[0] === "plan"
+        );
+        expect(planError?.message).toBe(
+          "明日の予定は2000文字以内で入力してください"
+        );
+      }
+    });
+  });
+
+  describe("visits validation", () => {
+    it("should pass with empty visits array", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "2024-01-15",
+        visits: [],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should validate nested visit records", () => {
+      const result = reportFormSchema.safeParse({
+        report_date: "2024-01-15",
+        visits: [
+          {
+            customer_id: "",
+            visit_content: "テスト",
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("getDefaultReportFormValues", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return today's date as report_date", () => {
+    const values = getDefaultReportFormValues();
+
+    expect(values.report_date).toBe("2024-01-15");
+  });
+
+  it("should return empty strings for optional fields", () => {
+    const values = getDefaultReportFormValues();
+
+    expect(values.problem).toBe("");
+    expect(values.plan).toBe("");
+  });
+
+  it("should return empty visits array", () => {
+    const values = getDefaultReportFormValues();
+
+    expect(values.visits).toEqual([]);
+  });
+});
+
+describe("getDefaultVisitRecordValues", () => {
+  it("should return default values for visit record", () => {
+    const values = getDefaultVisitRecordValues();
+
+    expect(values.customer_id).toBe("");
+    expect(values.visit_time).toBe("");
+    expect(values.visit_purpose).toBe("");
+    expect(values.visit_content).toBe("");
+    expect(values.visit_result).toBe("");
+  });
+});
+
+describe("validateReportDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return error for empty date", () => {
+    const result = validateReportDate("");
+
+    expect(result).toBe("報告日は必須です");
+  });
+
+  it("should return error for future date", () => {
+    const result = validateReportDate("2024-01-16");
+
+    expect(result).toBe("報告日に未来日は指定できません");
+  });
+
+  it("should return null for today's date", () => {
+    const result = validateReportDate("2024-01-15");
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null for past date", () => {
+    const result = validateReportDate("2024-01-14");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("validateForSubmission", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return error when report_date is empty", () => {
+    const errors = validateForSubmission({
+      report_date: "",
+      visits: [
+        {
+          customer_id: "1",
+          visit_content: "テスト",
+        },
+      ],
+    });
+
+    expect(errors).toContain("報告日は必須です");
+  });
+
+  it("should return error when report_date is future", () => {
+    const errors = validateForSubmission({
+      report_date: "2024-01-16",
+      visits: [
+        {
+          customer_id: "1",
+          visit_content: "テスト",
+        },
+      ],
+    });
+
+    expect(errors).toContain("報告日に未来日は指定できません");
+  });
+
+  it("should return error when visits is empty", () => {
+    const errors = validateForSubmission({
+      report_date: "2024-01-15",
+      visits: [],
+    });
+
+    expect(errors).toContain("提出時は訪問記録を1件以上登録してください");
+  });
+
+  it("should return empty array when valid for submission", () => {
+    const errors = validateForSubmission({
+      report_date: "2024-01-15",
+      visits: [
+        {
+          customer_id: "1",
+          visit_content: "テスト訪問内容",
+        },
+      ],
+    });
+
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("convertFormToApiRequest", () => {
+  it("should convert form values to API request format with draft status", () => {
+    const formData = {
+      report_date: "2024-01-15",
+      problem: "課題テスト",
+      plan: "予定テスト",
+      visits: [
+        {
+          customer_id: "1",
+          visit_time: "10:00",
+          visit_purpose: "商談",
+          visit_content: "新規提案を行いました",
+          visit_result: "次回アポイント取得",
+        },
+      ],
+    };
+
+    const result = convertFormToApiRequest(formData, "draft");
+
+    expect(result.report_date).toBe("2024-01-15");
+    expect(result.problem).toBe("課題テスト");
+    expect(result.plan).toBe("予定テスト");
+    expect(result.status).toBe("draft");
+    expect(result.visits).toHaveLength(1);
+    expect(result.visits[0]).toEqual({
+      customer_id: 1,
+      visit_time: "10:00",
+      visit_purpose: "商談",
+      visit_content: "新規提案を行いました",
+      visit_result: "次回アポイント取得",
+    });
+  });
+
+  it("should convert form values to API request format with submitted status", () => {
+    const formData = {
+      report_date: "2024-01-15",
+      visits: [
+        {
+          customer_id: "2",
+          visit_content: "テスト訪問",
+        },
+      ],
+    };
+
+    const result = convertFormToApiRequest(formData, "submitted");
+
+    expect(result.status).toBe("submitted");
+  });
+
+  it("should convert empty optional fields to null", () => {
+    const formData = {
+      report_date: "2024-01-15",
+      problem: "",
+      plan: "",
+      visits: [
+        {
+          customer_id: "1",
+          visit_time: "",
+          visit_purpose: "",
+          visit_content: "テスト",
+          visit_result: "",
+        },
+      ],
+    };
+
+    const result = convertFormToApiRequest(formData, "draft");
+
+    expect(result.problem).toBeNull();
+    expect(result.plan).toBeNull();
+    expect(result.visits[0]?.visit_time).toBeNull();
+    expect(result.visits[0]?.visit_purpose).toBeNull();
+    expect(result.visits[0]?.visit_result).toBeNull();
+  });
+
+  it("should parse customer_id as number", () => {
+    const formData = {
+      report_date: "2024-01-15",
+      visits: [
+        {
+          customer_id: "123",
+          visit_content: "テスト",
+        },
+      ],
+    };
+
+    const result = convertFormToApiRequest(formData, "draft");
+
+    expect(result.visits[0]?.customer_id).toBe(123);
+  });
+
+  it("should handle multiple visits", () => {
+    const formData = {
+      report_date: "2024-01-15",
+      visits: [
+        {
+          customer_id: "1",
+          visit_content: "訪問1",
+        },
+        {
+          customer_id: "2",
+          visit_content: "訪問2",
+        },
+        {
+          customer_id: "3",
+          visit_content: "訪問3",
+        },
+      ],
+    };
+
+    const result = convertFormToApiRequest(formData, "draft");
+
+    expect(result.visits).toHaveLength(3);
+    expect(result.visits[0]?.customer_id).toBe(1);
+    expect(result.visits[1]?.customer_id).toBe(2);
+    expect(result.visits[2]?.customer_id).toBe(3);
+  });
+});

--- a/src/features/reports/schemas.ts
+++ b/src/features/reports/schemas.ts
@@ -1,5 +1,5 @@
 /**
- * 日報一覧画面のバリデーションスキーマ
+ * 日報のバリデーションスキーマ
  */
 
 import { z } from "zod";
@@ -16,8 +16,156 @@ export const searchFormSchema = z.object({
 
 export type SearchFormValues = z.infer<typeof searchFormSchema>;
 
+// ============================================
+// 日報作成・編集フォームのスキーマ
+// ============================================
+
+/**
+ * 訪問記録フォームのスキーマ
+ */
+export const visitRecordFormSchema = z.object({
+  customer_id: z.string().min(1, "顧客を選択してください"),
+  visit_time: z.string().optional(),
+  visit_purpose: z
+    .string()
+    .max(100, "訪問目的は100文字以内で入力してください")
+    .optional(),
+  visit_content: z
+    .string()
+    .min(1, "訪問内容は必須です")
+    .max(1000, "訪問内容は1000文字以内で入力してください"),
+  visit_result: z
+    .string()
+    .max(200, "訪問結果は200文字以内で入力してください")
+    .optional(),
+});
+
+export type VisitRecordFormValues = z.infer<typeof visitRecordFormSchema>;
+
+/**
+ * 日報フォームのスキーマ
+ */
+export const reportFormSchema = z.object({
+  report_date: z.string().min(1, "報告日は必須です"),
+  problem: z
+    .string()
+    .max(2000, "課題・相談は2000文字以内で入力してください")
+    .optional(),
+  plan: z
+    .string()
+    .max(2000, "明日の予定は2000文字以内で入力してください")
+    .optional(),
+  visits: z.array(visitRecordFormSchema),
+});
+
+export type ReportFormValues = z.infer<typeof reportFormSchema>;
+
+/**
+ * 日報フォームのデフォルト値
+ */
+export function getDefaultReportFormValues(): ReportFormValues {
+  const today = new Date();
+  const formattedDate = today.toISOString().split("T")[0] ?? "";
+  return {
+    report_date: formattedDate,
+    problem: "",
+    plan: "",
+    visits: [],
+  };
+}
+
+/**
+ * 訪問記録のデフォルト値
+ */
+export function getDefaultVisitRecordValues(): VisitRecordFormValues {
+  return {
+    customer_id: "",
+    visit_time: "",
+    visit_purpose: "",
+    visit_content: "",
+    visit_result: "",
+  };
+}
+
+/**
+ * 報告日が未来日かどうかを検証
+ * @param dateStr - YYYY-MM-DD形式の日付文字列
+ * @returns エラーメッセージ。問題なければnull
+ */
+export function validateReportDate(dateStr: string): string | null {
+  if (!dateStr) {
+    return "報告日は必須です";
+  }
+
+  const reportDate = new Date(dateStr);
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+
+  if (reportDate > today) {
+    return "報告日に未来日は指定できません";
+  }
+
+  return null;
+}
+
+/**
+ * 提出時のバリデーション
+ * @param values - フォーム値
+ * @returns エラーメッセージの配列。問題なければ空配列
+ */
+export function validateForSubmission(values: ReportFormValues): string[] {
+  const errors: string[] = [];
+
+  // 報告日の検証
+  const dateError = validateReportDate(values.report_date);
+  if (dateError) {
+    errors.push(dateError);
+  }
+
+  // 訪問記録の必須チェック
+  if (values.visits.length === 0) {
+    errors.push("提出時は訪問記録を1件以上登録してください");
+  }
+
+  return errors;
+}
+
 /**
  * フォーム値をAPIリクエスト形式に変換
+ */
+export function convertFormToApiRequest(
+  formData: ReportFormValues,
+  status: "draft" | "submitted"
+): {
+  report_date: string;
+  problem: string | null;
+  plan: string | null;
+  status: "draft" | "submitted";
+  visits: Array<{
+    customer_id: number;
+    visit_time: string | null;
+    visit_purpose: string | null;
+    visit_content: string;
+    visit_result: string | null;
+  }>;
+} {
+  return {
+    report_date: formData.report_date,
+    problem: formData.problem || null,
+    plan: formData.plan || null,
+    status,
+    visits: formData.visits.map((visit) => ({
+      customer_id: parseInt(visit.customer_id, 10),
+      visit_time: visit.visit_time || null,
+      visit_purpose: visit.visit_purpose || null,
+      visit_content: visit.visit_content,
+      visit_result: visit.visit_result || null,
+    })),
+  };
+}
+
+/**
+ * 検索フォーム値をAPIリクエスト形式に変換
  */
 export function convertSearchFormToParams(formData: SearchFormValues): {
   date_from?: string;

--- a/src/features/reports/types.ts
+++ b/src/features/reports/types.ts
@@ -89,3 +89,123 @@ export interface ReportsSearchParams {
   sort?: "report_date" | "created_at";
   order?: "asc" | "desc";
 }
+
+// ============================================
+// 日報詳細・作成・編集用の型定義
+// ============================================
+
+/**
+ * 訪問記録（レスポンス用）
+ */
+export interface VisitRecord {
+  visit_id: number;
+  customer_id: number;
+  customer_name: string;
+  visit_time: string | null;
+  visit_purpose: string | null;
+  visit_content: string;
+  visit_result: string | null;
+}
+
+/**
+ * コメント
+ */
+export interface Comment {
+  comment_id: number;
+  sales_person_id: number;
+  sales_person_name: string;
+  comment_text: string;
+  created_at: string;
+}
+
+/**
+ * 日報詳細
+ */
+export interface ReportDetail {
+  report_id: number;
+  report_date: string;
+  sales_person_id: number;
+  sales_person_name: string;
+  status: ReportStatusType;
+  status_label: string;
+  problem: string | null;
+  plan: string | null;
+  visits: VisitRecord[];
+  comments: Comment[];
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 日報詳細取得APIレスポンス
+ */
+export interface ReportDetailResponse {
+  success: boolean;
+  data: ReportDetail;
+  message?: string;
+}
+
+/**
+ * 日報作成リクエスト
+ */
+export interface CreateReportRequest {
+  report_date: string;
+  problem: string | null;
+  plan: string | null;
+  status: "draft" | "submitted";
+  visits: Array<{
+    customer_id: number;
+    visit_time: string | null;
+    visit_purpose: string | null;
+    visit_content: string;
+    visit_result: string | null;
+  }>;
+}
+
+/**
+ * 日報作成APIレスポンス
+ */
+export interface CreateReportResponse {
+  success: boolean;
+  data: {
+    report_id: number;
+    report_date: string;
+    status: ReportStatusType;
+    created_at: string;
+  };
+  message?: string;
+}
+
+/**
+ * 日報更新APIレスポンス
+ */
+export interface UpdateReportResponse {
+  success: boolean;
+  data: {
+    report_id: number;
+    report_date: string;
+    status: ReportStatusType;
+    updated_at: string;
+  };
+  message?: string;
+}
+
+/**
+ * 顧客選択用
+ */
+export interface CustomerOption {
+  customer_id: number;
+  customer_name: string;
+}
+
+/**
+ * 顧客一覧取得APIレスポンス
+ */
+export interface CustomersOptionsResponse {
+  success: boolean;
+  data: {
+    items: CustomerOption[];
+    pagination: Pagination;
+  };
+  message?: string;
+}


### PR DESCRIPTION
## Summary
- 日報作成画面（SCR-011）・編集画面（SCR-012）の実装
- 日報作成ページ（/reports/new）
- 日報編集ページ（/reports/{id}/edit）
- 日報フォームコンポーネント（React Hook Form + Zod）
- 訪問記録の動的追加・削除機能

## 機能
- 報告日入力（デフォルト当日、未来日不可）
- 訪問記録の追加・削除
- 顧客選択（顧客マスタから）
- 訪問時間・目的・内容・結果の入力
- 課題・相談、明日の予定のテキストエリア
- 下書き保存（訪問記録0件でも可）
- 提出（訪問記録1件以上必須）
- 編集制約（確認済は編集不可、本人のみ編集可能）

## Test plan
- [ ] 日報を新規作成できる
- [ ] 訪問記録を複数追加・削除できる
- [ ] 下書き保存ができる
- [ ] 提出ができる
- [ ] 既存日報を編集できる
- [ ] 確認済の日報は編集画面に遷移できない
- [ ] テスト47件がすべてパスすることを確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)