### PR TITLE
feat: Issue #14 日報詳細画面の実装

### DIFF
--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -1,0 +1,212 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
+import { Button } from "@/components/ui/button";
+import { ReportDetailView } from "@/features/reports/components";
+import { prisma } from "@/lib/prisma";
+
+import type {
+  ReportDetail as ReportDetailType,
+  VisitRecord,
+  Comment,
+} from "@/features/reports/types";
+import type { ReportStatusType } from "@/lib/api/schemas/report";
+
+interface ReportDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "日報詳細 | 営業日報システム",
+  description: "日報の詳細を表示します",
+};
+
+// 動的レンダリングを強制（認証が必要なページ）
+export const dynamic = "force-dynamic";
+
+/**
+ * 訪問時間をHH:MM形式に変換
+ */
+function formatVisitTime(date: Date | null): string | null {
+  if (!date) {
+    return null;
+  }
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * ログインユーザーが日報にアクセス可能かチェック
+ */
+async function canAccessReport(
+  userId: number,
+  isManager: boolean,
+  reportOwnerId: number
+): Promise<boolean> {
+  // 自分の日報なら常にアクセス可能
+  if (userId === reportOwnerId) {
+    return true;
+  }
+
+  // 上長でない場合はアクセス不可
+  if (!isManager) {
+    return false;
+  }
+
+  // 上長の場合、部下の日報かどうかチェック
+  const subordinate = await prisma.salesPerson.findFirst({
+    where: {
+      id: reportOwnerId,
+      managerId: userId,
+    },
+  });
+
+  return subordinate !== null;
+}
+
+/**
+ * 日報データを取得
+ */
+async function getReport(
+  reportId: number,
+  userId: number,
+  isManager: boolean
+): Promise<ReportDetailType | null> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    include: {
+      salesPerson: {
+        select: { name: true },
+      },
+      visitRecords: {
+        include: {
+          customer: {
+            select: { customerName: true },
+          },
+        },
+        orderBy: { visitTime: "asc" },
+      },
+      comments: {
+        include: {
+          salesPerson: {
+            select: { name: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!report) {
+    return null;
+  }
+
+  // アクセス権限チェック
+  const canAccess = await canAccessReport(
+    userId,
+    isManager,
+    report.salesPersonId
+  );
+
+  if (!canAccess) {
+    return null;
+  }
+
+  const status = report.status as ReportStatusType;
+  const dateStr = report.reportDate.toISOString().split("T")[0];
+
+  const visits: VisitRecord[] = report.visitRecords.map((v) => ({
+    visit_id: v.id,
+    customer_id: v.customerId,
+    customer_name: v.customer.customerName,
+    visit_time: formatVisitTime(v.visitTime),
+    visit_purpose: v.visitPurpose,
+    visit_content: v.visitContent,
+    visit_result: v.visitResult,
+  }));
+
+  const comments: Comment[] = report.comments.map((c) => ({
+    comment_id: c.id,
+    sales_person_id: c.salesPersonId,
+    sales_person_name: c.salesPerson.name,
+    comment_text: c.commentText,
+    created_at: c.createdAt.toISOString(),
+  }));
+
+  const statusLabels: Record<ReportStatusType, string> = {
+    draft: "下書き",
+    submitted: "提出済",
+    confirmed: "確認済",
+  };
+
+  return {
+    report_id: report.id,
+    report_date: dateStr ?? "",
+    sales_person_id: report.salesPersonId,
+    sales_person_name: report.salesPerson.name,
+    status,
+    status_label: statusLabels[status],
+    problem: report.problem,
+    plan: report.plan,
+    visits,
+    comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  };
+}
+
+export default async function ReportDetailPage({
+  params,
+}: ReportDetailPageProps) {
+  // 認証チェック
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  // パラメータを取得
+  const { id } = await params;
+  const reportId = parseInt(id, 10);
+
+  if (isNaN(reportId)) {
+    notFound();
+  }
+
+  // 日報データを取得
+  const report = await getReport(
+    reportId,
+    session.user.id,
+    session.user.isManager
+  );
+
+  if (!report) {
+    notFound();
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/reports">
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              日報一覧に戻る
+            </Link>
+          </Button>
+        </div>
+        <h1 className="text-2xl font-bold">日報詳細</h1>
+        <ReportDetailView
+          report={report}
+          currentUser={{
+            id: session.user.id,
+            isManager: session.user.isManager,
+          }}
+        />
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/features/reports/api.ts
+++ b/src/features/reports/api.ts
@@ -6,14 +6,17 @@ import { REPORTS_API_BASE } from "./constants";
 
 import type {
   ApiErrorResponse,
+  CreateCommentResponse,
   CreateReportRequest,
   CreateReportResponse,
   CustomersOptionsResponse,
+  DeleteCommentResponse,
   ReportDetailResponse,
   ReportsListResponse,
   ReportsSearchParams,
   SalesPersonsOptionsResponse,
   UpdateReportResponse,
+  UpdateStatusResponse,
 } from "./types";
 
 /**
@@ -182,6 +185,75 @@ export async function fetchCustomersForSelect(): Promise<CustomersOptionsRespons
   if (!response.ok) {
     const errorData = (await response.json()) as ApiErrorResponse;
     throw new Error(errorData.error?.message || "顧客一覧の取得に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * 日報のステータスを更新
+ */
+export async function updateReportStatus(
+  reportId: number,
+  status: "draft" | "submitted" | "confirmed"
+): Promise<UpdateStatusResponse> {
+  const response = await fetch(`${REPORTS_API_BASE}/${reportId}/status`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(
+      errorData.error?.message || "ステータスの更新に失敗しました"
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * コメントを作成
+ */
+export async function createComment(
+  reportId: number,
+  commentText: string
+): Promise<CreateCommentResponse> {
+  const response = await fetch(`${REPORTS_API_BASE}/${reportId}/comments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ comment_text: commentText }),
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "コメントの投稿に失敗しました");
+  }
+
+  return response.json();
+}
+
+/**
+ * コメントを削除
+ */
+export async function deleteComment(
+  commentId: number
+): Promise<DeleteCommentResponse> {
+  const response = await fetch(`/api/v1/comments/${commentId}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json()) as ApiErrorResponse;
+    throw new Error(errorData.error?.message || "コメントの削除に失敗しました");
   }
 
   return response.json();

--- a/src/features/reports/components/CommentForm.test.tsx
+++ b/src/features/reports/components/CommentForm.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen, mockManagerUser, waitFor } from "@/test/test-utils";
+
+import { CommentForm } from "./CommentForm";
+
+describe("CommentForm", () => {
+  describe("rendering", () => {
+    it("should render card with title", () => {
+      render(<CommentForm onSubmit={vi.fn()} />, {
+        user: mockManagerUser,
+      });
+
+      expect(screen.getByText("コメントを投稿")).toBeInTheDocument();
+    });
+
+    it("should render textarea", () => {
+      render(<CommentForm onSubmit={vi.fn()} />, {
+        user: mockManagerUser,
+      });
+
+      expect(
+        screen.getByPlaceholderText("コメントを入力してください...")
+      ).toBeInTheDocument();
+    });
+
+    it("should render submit button", () => {
+      render(<CommentForm onSubmit={vi.fn()} />, {
+        user: mockManagerUser,
+      });
+
+      expect(
+        screen.getByRole("button", { name: /コメントを送信/ })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("validation", () => {
+    it("should show error when submitting empty comment", async () => {
+      const onSubmit = vi.fn();
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("コメントを入力してください")
+        ).toBeInTheDocument();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("should show error when comment exceeds 500 characters", async () => {
+      const onSubmit = vi.fn();
+      const longText = "あ".repeat(501);
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      await user.type(
+        screen.getByPlaceholderText("コメントを入力してください..."),
+        longText
+      );
+
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("コメントは500文字以内で入力してください")
+        ).toBeInTheDocument();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submission", () => {
+    it("should call onSubmit with comment text when valid", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      await user.type(
+        screen.getByPlaceholderText("コメントを入力してください..."),
+        "テストコメントです"
+      );
+
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("テストコメントです");
+      });
+    });
+
+    it("should clear textarea after successful submission", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      const textarea =
+        screen.getByPlaceholderText("コメントを入力してください...");
+
+      await user.type(textarea, "テストコメントです");
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(textarea).toHaveValue("");
+      });
+    });
+
+    it("should show loading state during submission", async () => {
+      const onSubmit = vi
+        .fn()
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(resolve, 100))
+        );
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      await user.type(
+        screen.getByPlaceholderText("コメントを入力してください..."),
+        "テストコメントです"
+      );
+
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("送信中...")).toBeInTheDocument();
+      });
+    });
+
+    it("should disable button during submission", async () => {
+      const onSubmit = vi
+        .fn()
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(resolve, 100))
+        );
+
+      const { user } = render(<CommentForm onSubmit={onSubmit} />, {
+        user: mockManagerUser,
+      });
+
+      await user.type(
+        screen.getByPlaceholderText("コメントを入力してください..."),
+        "テストコメントです"
+      );
+
+      await user.click(screen.getByRole("button", { name: /コメントを送信/ }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /送信中/ })).toBeDisabled();
+      });
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have accessible textarea", () => {
+      render(<CommentForm onSubmit={vi.fn()} />, {
+        user: mockManagerUser,
+      });
+
+      // テキストエリアの存在確認
+      const textarea = screen.getByRole("textbox", { name: /コメント内容/i });
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it("should have visible placeholder text", () => {
+      render(<CommentForm onSubmit={vi.fn()} />, {
+        user: mockManagerUser,
+      });
+
+      expect(
+        screen.getByPlaceholderText("コメントを入力してください...")
+      ).toBeVisible();
+    });
+  });
+});

--- a/src/features/reports/components/CommentForm.tsx
+++ b/src/features/reports/components/CommentForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Send } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * コメント入力フォームのバリデーションスキーマ
+ */
+const commentFormSchema = z.object({
+  comment_text: z
+    .string()
+    .min(1, "コメントを入力してください")
+    .max(500, "コメントは500文字以内で入力してください"),
+});
+
+type CommentFormValues = z.infer<typeof commentFormSchema>;
+
+interface CommentFormProps {
+  onSubmit: (commentText: string) => Promise<void>;
+}
+
+/**
+ * コメント入力フォームコンポーネント
+ * 上長のみ表示され、コメントを投稿できる
+ */
+export function CommentForm({ onSubmit }: CommentFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<CommentFormValues>({
+    resolver: zodResolver(commentFormSchema),
+    defaultValues: {
+      comment_text: "",
+    },
+  });
+
+  const handleSubmit = async (values: CommentFormValues) => {
+    setIsSubmitting(true);
+    try {
+      await onSubmit(values.comment_text);
+      form.reset();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">コメントを投稿</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="comment_text"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="sr-only">コメント内容</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="コメントを入力してください..."
+                      className="min-h-[100px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={isSubmitting}>
+                <Send className="mr-2 h-4 w-4" aria-hidden="true" />
+                {isSubmitting ? "送信中..." : "コメントを送信"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reports/components/CommentList.test.tsx
+++ b/src/features/reports/components/CommentList.test.tsx
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  render,
+  screen,
+  mockMemberUser,
+  mockManagerUser,
+  waitFor,
+} from "@/test/test-utils";
+
+import { CommentList } from "./CommentList";
+
+import type { Comment } from "../types";
+
+describe("CommentList", () => {
+  const mockComments: Comment[] = [
+    {
+      comment_id: 1,
+      sales_person_id: 2,
+      sales_person_name: "上長太郎",
+      comment_text: "よく頑張っています。引き続きお願いします。",
+      created_at: "2024-01-15T18:00:00Z",
+    },
+    {
+      comment_id: 2,
+      sales_person_id: 3,
+      sales_person_name: "別の上長",
+      comment_text: "来週の報告も楽しみにしています。",
+      created_at: "2024-01-16T10:00:00Z",
+    },
+  ];
+
+  describe("rendering", () => {
+    it("should render card with title", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("コメント")).toBeInTheDocument();
+    });
+
+    it("should display comment count", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("(2件)")).toBeInTheDocument();
+    });
+
+    it("should display commenter names", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("上長太郎")).toBeInTheDocument();
+      expect(screen.getByText("別の上長")).toBeInTheDocument();
+    });
+
+    it("should display comment texts", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(
+        screen.getByText("よく頑張っています。引き続きお願いします。")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("来週の報告も楽しみにしています。")
+      ).toBeInTheDocument();
+    });
+
+    it("should display formatted dates", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      // 日時がフォーマットされて表示される（複数あるのでgetAllByTextを使用）
+      expect(screen.getAllByText(/2024/).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("empty state", () => {
+    it("should display empty message when no comments", () => {
+      render(<CommentList comments={[]} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("コメントはありません。")).toBeInTheDocument();
+    });
+
+    it("should not display count when empty", () => {
+      render(<CommentList comments={[]} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.queryByText(/件/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("delete button", () => {
+    it("should show delete button for own comments", () => {
+      const ownComment: Comment[] = [
+        {
+          comment_id: 1,
+          sales_person_id: 2, // mockManagerUser.id
+          sales_person_name: "テスト上長",
+          comment_text: "自分のコメント",
+          created_at: "2024-01-15T18:00:00Z",
+        },
+      ];
+
+      render(
+        <CommentList
+          comments={ownComment}
+          currentUserId={2}
+          onDelete={vi.fn()}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(
+        screen.getByRole("button", { name: "コメントを削除" })
+      ).toBeInTheDocument();
+    });
+
+    it("should not show delete button for other users comments", () => {
+      render(
+        <CommentList
+          comments={mockComments}
+          currentUserId={1}
+          onDelete={vi.fn()}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "コメントを削除" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show delete button when onDelete is not provided", () => {
+      const ownComment: Comment[] = [
+        {
+          comment_id: 1,
+          sales_person_id: 2,
+          sales_person_name: "テスト上長",
+          comment_text: "自分のコメント",
+          created_at: "2024-01-15T18:00:00Z",
+        },
+      ];
+
+      render(<CommentList comments={ownComment} currentUserId={2} />, {
+        user: mockManagerUser,
+      });
+
+      expect(
+        screen.queryByRole("button", { name: "コメントを削除" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("delete confirmation dialog", () => {
+    it("should open confirmation dialog when delete button is clicked", async () => {
+      const ownComment: Comment[] = [
+        {
+          comment_id: 1,
+          sales_person_id: 2,
+          sales_person_name: "テスト上長",
+          comment_text: "自分のコメント",
+          created_at: "2024-01-15T18:00:00Z",
+        },
+      ];
+
+      const { user } = render(
+        <CommentList
+          comments={ownComment}
+          currentUserId={2}
+          onDelete={vi.fn()}
+        />,
+        { user: mockManagerUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: "コメントを削除" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("コメントを削除しますか？")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should call onDelete when confirmed", async () => {
+      const ownComment: Comment[] = [
+        {
+          comment_id: 1,
+          sales_person_id: 2,
+          sales_person_name: "テスト上長",
+          comment_text: "自分のコメント",
+          created_at: "2024-01-15T18:00:00Z",
+        },
+      ];
+      const onDelete = vi.fn().mockResolvedValue(undefined);
+
+      const { user } = render(
+        <CommentList
+          comments={ownComment}
+          currentUserId={2}
+          onDelete={onDelete}
+        />,
+        { user: mockManagerUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: "コメントを削除" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("コメントを削除しますか？")
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "削除" }));
+
+      await waitFor(() => {
+        expect(onDelete).toHaveBeenCalledWith(1);
+      });
+    });
+
+    it("should close dialog when cancelled", async () => {
+      const ownComment: Comment[] = [
+        {
+          comment_id: 1,
+          sales_person_id: 2,
+          sales_person_name: "テスト上長",
+          comment_text: "自分のコメント",
+          created_at: "2024-01-15T18:00:00Z",
+        },
+      ];
+      const onDelete = vi.fn();
+
+      const { user } = render(
+        <CommentList
+          comments={ownComment}
+          currentUserId={2}
+          onDelete={onDelete}
+        />,
+        { user: mockManagerUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: "コメントを削除" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("コメントを削除しますか？")
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("コメントを削除しますか？")
+        ).not.toBeInTheDocument();
+      });
+
+      expect(onDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have list role for comments container", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(
+        screen.getByRole("list", { name: "コメント一覧" })
+      ).toBeInTheDocument();
+    });
+
+    it("should have listitem role for each comment", () => {
+      render(<CommentList comments={mockComments} currentUserId={1} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    });
+  });
+});

--- a/src/features/reports/components/CommentList.tsx
+++ b/src/features/reports/components/CommentList.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { MessageSquare, Trash2, User } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import type { Comment } from "../types";
+
+interface CommentListProps {
+  comments: Comment[];
+  currentUserId: number;
+  onDelete?: (commentId: number) => Promise<void>;
+}
+
+/**
+ * コメント一覧コンポーネント
+ * コメントの一覧表示と削除機能
+ */
+export function CommentList({
+  comments,
+  currentUserId,
+  onDelete,
+}: CommentListProps) {
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [openDialogId, setOpenDialogId] = useState<number | null>(null);
+
+  const handleDelete = async (commentId: number) => {
+    if (!onDelete) {
+      return;
+    }
+
+    setDeletingId(commentId);
+    try {
+      await onDelete(commentId);
+      setOpenDialogId(null);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  /**
+   * 日時をフォーマット
+   */
+  const formatDateTime = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <MessageSquare className="h-5 w-5" aria-hidden="true" />
+          コメント
+          {comments.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              ({comments.length}件)
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {comments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            コメントはありません。
+          </p>
+        ) : (
+          <div className="space-y-4" role="list" aria-label="コメント一覧">
+            {comments.map((comment) => (
+              <div
+                key={comment.comment_id}
+                className="rounded-lg border p-4"
+                role="listitem"
+              >
+                <div className="mb-2 flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                      <User className="h-4 w-4" aria-hidden="true" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium">
+                        {comment.sales_person_name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDateTime(comment.created_at)}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* 投稿者本人のみ削除可能 */}
+                  {comment.sales_person_id === currentUserId && onDelete && (
+                    <Dialog
+                      open={openDialogId === comment.comment_id}
+                      onOpenChange={(open) =>
+                        setOpenDialogId(open ? comment.comment_id : null)
+                      }
+                    >
+                      <DialogTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                          disabled={deletingId === comment.comment_id}
+                          aria-label="コメントを削除"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>コメントを削除しますか？</DialogTitle>
+                          <DialogDescription>
+                            この操作は取り消せません。コメントは完全に削除されます。
+                          </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                          <DialogClose asChild>
+                            <Button variant="outline">キャンセル</Button>
+                          </DialogClose>
+                          <Button
+                            variant="destructive"
+                            onClick={() => handleDelete(comment.comment_id)}
+                            disabled={deletingId === comment.comment_id}
+                          >
+                            {deletingId === comment.comment_id
+                              ? "削除中..."
+                              : "削除"}
+                          </Button>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
+                  )}
+                </div>
+
+                <p className="whitespace-pre-wrap text-sm">
+                  {comment.comment_text}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reports/components/ReportBasicInfo.test.tsx
+++ b/src/features/reports/components/ReportBasicInfo.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+
+import { render, screen, mockMemberUser } from "@/test/test-utils";
+
+import { ReportBasicInfo } from "./ReportBasicInfo";
+
+describe("ReportBasicInfo", () => {
+  const defaultProps = {
+    reportDate: "2024-01-15",
+    salesPersonName: "山田太郎",
+    status: "submitted" as const,
+  };
+
+  describe("rendering", () => {
+    it("should render basic info card with title", () => {
+      render(<ReportBasicInfo {...defaultProps} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("基本情報")).toBeInTheDocument();
+    });
+
+    it("should display report date formatted in Japanese", () => {
+      render(<ReportBasicInfo {...defaultProps} />, {
+        user: mockMemberUser,
+      });
+
+      // 日付がフォーマットされて表示される（例: 2024年1月15日(月)）
+      expect(screen.getByText(/2024年1月15日/)).toBeInTheDocument();
+    });
+
+    it("should display sales person name", () => {
+      render(<ReportBasicInfo {...defaultProps} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("山田太郎")).toBeInTheDocument();
+    });
+
+    it("should display labels for each field", () => {
+      render(<ReportBasicInfo {...defaultProps} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("報告日")).toBeInTheDocument();
+      expect(screen.getByText("担当者")).toBeInTheDocument();
+      expect(screen.getByText("ステータス")).toBeInTheDocument();
+    });
+  });
+
+  describe("status badge", () => {
+    it("should display draft status", () => {
+      render(<ReportBasicInfo {...defaultProps} status="draft" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("下書き")).toBeInTheDocument();
+    });
+
+    it("should display submitted status", () => {
+      render(<ReportBasicInfo {...defaultProps} status="submitted" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("提出済")).toBeInTheDocument();
+    });
+
+    it("should display confirmed status", () => {
+      render(<ReportBasicInfo {...defaultProps} status="confirmed" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("確認済")).toBeInTheDocument();
+    });
+  });
+
+  describe("date formatting", () => {
+    it("should format different dates correctly", () => {
+      render(<ReportBasicInfo {...defaultProps} reportDate="2024-12-25" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText(/2024年12月25日/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/reports/components/ReportBasicInfo.tsx
+++ b/src/features/reports/components/ReportBasicInfo.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { CalendarDays, User } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { ReportStatusBadge } from "./ReportStatusBadge";
+
+import type { ReportStatusType } from "@/lib/api/schemas/report";
+
+interface ReportBasicInfoProps {
+  reportDate: string;
+  salesPersonName: string;
+  status: ReportStatusType;
+}
+
+/**
+ * 日報基本情報表示コンポーネント
+ * 報告日、担当者名、ステータスを表示
+ */
+export function ReportBasicInfo({
+  reportDate,
+  salesPersonName,
+  status,
+}: ReportBasicInfoProps) {
+  // 日付をフォーマット
+  const formattedDate = new Date(reportDate).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">基本情報</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid gap-4 sm:grid-cols-3">
+          <div className="flex items-start gap-2">
+            <CalendarDays
+              className="mt-0.5 h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                報告日
+              </dt>
+              <dd className="text-sm">{formattedDate}</dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-2">
+            <User
+              className="mt-0.5 h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                担当者
+              </dt>
+              <dd className="text-sm">{salesPersonName}</dd>
+            </div>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-muted-foreground">
+              ステータス
+            </dt>
+            <dd className="mt-1">
+              <ReportStatusBadge status={status} />
+            </dd>
+          </div>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reports/components/ReportDetail.test.tsx
+++ b/src/features/reports/components/ReportDetail.test.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  render,
+  screen,
+  mockMemberUser,
+  mockManagerUser,
+  waitFor,
+} from "@/test/test-utils";
+
+import { ReportDetailView } from "./ReportDetail";
+
+import type { ReportDetail as ReportDetailType } from "../types";
+
+// router.refreshのモック
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+// API関数のモック
+vi.mock("../api", () => ({
+  updateReportStatus: vi.fn(),
+  createComment: vi.fn(),
+  deleteComment: vi.fn(),
+}));
+
+// toast のモック
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("ReportDetailView", () => {
+  const mockReport: ReportDetailType = {
+    report_id: 1,
+    report_date: "2024-01-15",
+    sales_person_id: 1,
+    sales_person_name: "山田太郎",
+    status: "submitted",
+    status_label: "提出済",
+    problem: "課題テスト",
+    plan: "予定テスト",
+    visits: [
+      {
+        visit_id: 1,
+        customer_id: 1,
+        customer_name: "株式会社ABC",
+        visit_time: "10:00",
+        visit_purpose: "商品説明",
+        visit_content: "商品の説明を行いました",
+        visit_result: "継続検討",
+      },
+    ],
+    comments: [
+      {
+        comment_id: 1,
+        sales_person_id: 2,
+        sales_person_name: "上長太郎",
+        comment_text: "確認しました",
+        created_at: "2024-01-15T18:00:00Z",
+      },
+    ],
+    created_at: "2024-01-15T10:00:00Z",
+    updated_at: "2024-01-15T17:00:00Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("basic rendering", () => {
+    it("should render basic info section", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByText("基本情報")).toBeInTheDocument();
+      expect(screen.getByText("山田太郎")).toBeInTheDocument();
+    });
+
+    it("should render visit records section", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByText("訪問記録")).toBeInTheDocument();
+      expect(screen.getByText("株式会社ABC")).toBeInTheDocument();
+    });
+
+    it("should render problem section", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByText("課題・相談")).toBeInTheDocument();
+      expect(screen.getByText("課題テスト")).toBeInTheDocument();
+    });
+
+    it("should render plan section", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByText("明日の予定")).toBeInTheDocument();
+      expect(screen.getByText("予定テスト")).toBeInTheDocument();
+    });
+
+    it("should render comments section", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByText("コメント")).toBeInTheDocument();
+      expect(screen.getByText("確認しました")).toBeInTheDocument();
+    });
+
+    it("should show empty message for null problem", () => {
+      const reportWithoutProblem = {
+        ...mockReport,
+        problem: null,
+      };
+
+      render(
+        <ReportDetailView
+          report={reportWithoutProblem}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getAllByText("記載なし")).toHaveLength(1);
+    });
+
+    it("should show empty message for null plan", () => {
+      const reportWithoutPlan = {
+        ...mockReport,
+        plan: null,
+      };
+
+      render(
+        <ReportDetailView
+          report={reportWithoutPlan}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getAllByText("記載なし")).toHaveLength(1);
+    });
+  });
+
+  describe("edit button visibility", () => {
+    it("should show edit button for own draft report", () => {
+      const draftReport = { ...mockReport, status: "draft" as const };
+
+      render(
+        <ReportDetailView
+          report={draftReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByRole("link", { name: /編集/ })).toBeInTheDocument();
+    });
+
+    it("should show edit button for own submitted report", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByRole("link", { name: /編集/ })).toBeInTheDocument();
+    });
+
+    it("should not show edit button for confirmed report", () => {
+      const confirmedReport = {
+        ...mockReport,
+        status: "confirmed" as const,
+      };
+
+      render(
+        <ReportDetailView
+          report={confirmedReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(
+        screen.queryByRole("link", { name: /編集/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show edit button for other users report", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 99, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(
+        screen.queryByRole("link", { name: /編集/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should have correct edit link href", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.getByRole("link", { name: /編集/ })).toHaveAttribute(
+        "href",
+        "/reports/1/edit"
+      );
+    });
+  });
+
+  describe("confirm button visibility", () => {
+    it("should show confirm button for manager viewing submitted report", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(
+        screen.getByRole("button", { name: /確認済にする/ })
+      ).toBeInTheDocument();
+    });
+
+    it("should not show confirm button for draft report", () => {
+      const draftReport = { ...mockReport, status: "draft" as const };
+
+      render(
+        <ReportDetailView
+          report={draftReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /確認済にする/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show confirm button for confirmed report", () => {
+      const confirmedReport = {
+        ...mockReport,
+        status: "confirmed" as const,
+      };
+
+      render(
+        <ReportDetailView
+          report={confirmedReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /確認済にする/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show confirm button for non-manager", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /確認済にする/ })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("comment form visibility", () => {
+    it("should show comment form for manager", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      expect(screen.getByText("コメントを投稿")).toBeInTheDocument();
+    });
+
+    it("should not show comment form for non-manager", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(screen.queryByText("コメントを投稿")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("confirmed status alert", () => {
+    it("should show alert for confirmed report", () => {
+      const confirmedReport = {
+        ...mockReport,
+        status: "confirmed" as const,
+      };
+
+      render(
+        <ReportDetailView
+          report={confirmedReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(
+        screen.getByText("この日報は確認済です。編集することはできません。")
+      ).toBeInTheDocument();
+    });
+
+    it("should not show alert for non-confirmed report", () => {
+      render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 1, isManager: false }}
+        />,
+        { user: mockMemberUser }
+      );
+
+      expect(
+        screen.queryByText("この日報は確認済です。編集することはできません。")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("confirm action", () => {
+    it("should call updateReportStatus when confirm button is clicked", async () => {
+      const { updateReportStatus } = await import("../api");
+      (updateReportStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { status: "confirmed" },
+      });
+
+      const { user } = render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: /確認済にする/ }));
+
+      await waitFor(() => {
+        expect(updateReportStatus).toHaveBeenCalledWith(1, "confirmed");
+      });
+    });
+
+    it("should show loading state during confirm", async () => {
+      const { updateReportStatus } = await import("../api");
+      (updateReportStatus as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+
+      const { user } = render(
+        <ReportDetailView
+          report={mockReport}
+          currentUser={{ id: 2, isManager: true }}
+        />,
+        { user: mockManagerUser }
+      );
+
+      await user.click(screen.getByRole("button", { name: /確認済にする/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("処理中...")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/features/reports/components/ReportDetail.tsx
+++ b/src/features/reports/components/ReportDetail.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, Edit, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { createComment, deleteComment, updateReportStatus } from "../api";
+import { CommentForm } from "./CommentForm";
+import { CommentList } from "./CommentList";
+import { ReportBasicInfo } from "./ReportBasicInfo";
+import { VisitRecordDisplay } from "./VisitRecordDisplay";
+
+import type { ReportDetail as ReportDetailType } from "../types";
+
+interface ReportDetailViewProps {
+  report: ReportDetailType;
+  currentUser: {
+    id: number;
+    isManager: boolean;
+  };
+}
+
+/**
+ * 日報詳細表示メインコンポーネント
+ * 基本情報、訪問記録、課題・相談、明日の予定、コメントを表示
+ */
+export function ReportDetailView({
+  report,
+  currentUser,
+}: ReportDetailViewProps) {
+  const router = useRouter();
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+  const [comments, setComments] = useState(report.comments);
+  const [currentStatus, setCurrentStatus] = useState(report.status);
+
+  // 編集ボタン表示条件: 本人かつ未確認（draft/submitted）
+  const canEdit =
+    report.sales_person_id === currentUser.id && currentStatus !== "confirmed";
+
+  // 確認済ボタン表示条件: 上長かつ提出済（submitted）
+  const canConfirm = currentUser.isManager && currentStatus === "submitted";
+
+  // コメント投稿可能条件: 上長のみ
+  const canComment = currentUser.isManager;
+
+  /**
+   * ステータスを確認済に更新
+   */
+  const handleConfirm = async () => {
+    setIsUpdatingStatus(true);
+    try {
+      const response = await updateReportStatus(report.report_id, "confirmed");
+      setCurrentStatus(response.data.status);
+      toast.success("日報を確認済にしました");
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "ステータスの更新に失敗しました"
+      );
+    } finally {
+      setIsUpdatingStatus(false);
+    }
+  };
+
+  /**
+   * コメントを投稿
+   */
+  const handleCommentSubmit = async (commentText: string) => {
+    try {
+      await createComment(report.report_id, commentText);
+      toast.success("コメントを投稿しました");
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "コメントの投稿に失敗しました"
+      );
+      throw error;
+    }
+  };
+
+  /**
+   * コメントを削除
+   */
+  const handleCommentDelete = async (commentId: number) => {
+    try {
+      await deleteComment(commentId);
+      setComments((prev) => prev.filter((c) => c.comment_id !== commentId));
+      toast.success("コメントを削除しました");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "コメントの削除に失敗しました"
+      );
+      throw error;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* アクションボタン */}
+      <div className="flex flex-wrap gap-2">
+        {canEdit && (
+          <Button asChild>
+            <Link href={`/reports/${report.report_id}/edit`}>
+              <Edit className="mr-2 h-4 w-4" aria-hidden="true" />
+              編集
+            </Link>
+          </Button>
+        )}
+
+        {canConfirm && (
+          <Button
+            onClick={handleConfirm}
+            disabled={isUpdatingStatus}
+            variant="secondary"
+          >
+            {isUpdatingStatus ? (
+              <Loader2
+                className="mr-2 h-4 w-4 animate-spin"
+                aria-hidden="true"
+              />
+            ) : (
+              <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
+            )}
+            {isUpdatingStatus ? "処理中..." : "確認済にする"}
+          </Button>
+        )}
+      </div>
+
+      {/* 確認済の場合の注意表示 */}
+      {currentStatus === "confirmed" && (
+        <Alert>
+          <CheckCircle2 className="h-4 w-4" />
+          <AlertDescription>
+            この日報は確認済です。編集することはできません。
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* 基本情報 */}
+      <ReportBasicInfo
+        reportDate={report.report_date}
+        salesPersonName={report.sales_person_name}
+        status={currentStatus}
+      />
+
+      {/* 訪問記録 */}
+      <VisitRecordDisplay visits={report.visits} />
+
+      {/* 課題・相談 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+            課題・相談
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {report.problem ? (
+            <p className="whitespace-pre-wrap text-sm">{report.problem}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">記載なし</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 明日の予定 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">明日の予定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {report.plan ? (
+            <p className="whitespace-pre-wrap text-sm">{report.plan}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">記載なし</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* コメント一覧 */}
+      <CommentList
+        comments={comments}
+        currentUserId={currentUser.id}
+        onDelete={handleCommentDelete}
+      />
+
+      {/* コメント入力フォーム（上長のみ） */}
+      {canComment && <CommentForm onSubmit={handleCommentSubmit} />}
+    </div>
+  );
+}

--- a/src/features/reports/components/VisitRecordDisplay.test.tsx
+++ b/src/features/reports/components/VisitRecordDisplay.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+
+import { render, screen, mockMemberUser } from "@/test/test-utils";
+
+import { VisitRecordDisplay } from "./VisitRecordDisplay";
+
+import type { VisitRecord } from "../types";
+
+describe("VisitRecordDisplay", () => {
+  const mockVisits: VisitRecord[] = [
+    {
+      visit_id: 1,
+      customer_id: 1,
+      customer_name: "株式会社ABC",
+      visit_time: "10:00",
+      visit_purpose: "商品説明",
+      visit_content: "新商品の説明と提案を行いました。",
+      visit_result: "次回見積り提出予定",
+    },
+    {
+      visit_id: 2,
+      customer_id: 2,
+      customer_name: "株式会社XYZ",
+      visit_time: "14:30",
+      visit_purpose: null,
+      visit_content: "定期訪問による状況確認",
+      visit_result: null,
+    },
+  ];
+
+  describe("rendering", () => {
+    it("should render card with title", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("訪問記録")).toBeInTheDocument();
+    });
+
+    it("should display visit count", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("2件の訪問")).toBeInTheDocument();
+    });
+
+    it("should display customer names", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("株式会社ABC")).toBeInTheDocument();
+      expect(screen.getByText("株式会社XYZ")).toBeInTheDocument();
+    });
+
+    it("should display visit times", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("10:00")).toBeInTheDocument();
+      expect(screen.getByText("14:30")).toBeInTheDocument();
+    });
+
+    it("should display visit content", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(
+        screen.getByText("新商品の説明と提案を行いました。")
+      ).toBeInTheDocument();
+      expect(screen.getByText("定期訪問による状況確認")).toBeInTheDocument();
+    });
+
+    it("should display visit purpose when provided", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("商品説明")).toBeInTheDocument();
+    });
+
+    it("should display visit result when provided", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("次回見積り提出予定")).toBeInTheDocument();
+    });
+
+    it("should display labels for visit sections", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("訪問目的")).toBeInTheDocument();
+      expect(screen.getAllByText("訪問内容")).toHaveLength(2);
+      expect(screen.getByText("訪問結果")).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("should display empty message when no visits", () => {
+      render(<VisitRecordDisplay visits={[]} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("訪問記録はありません。")).toBeInTheDocument();
+    });
+
+    it("should not display visit count when empty", () => {
+      render(<VisitRecordDisplay visits={[]} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.queryByText(/件の訪問/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("optional fields", () => {
+    it("should not display purpose section when null", () => {
+      const visitWithoutPurpose: VisitRecord[] = [
+        {
+          visit_id: 1,
+          customer_id: 1,
+          customer_name: "テスト会社",
+          visit_time: null,
+          visit_purpose: null,
+          visit_content: "テスト内容",
+          visit_result: null,
+        },
+      ];
+
+      render(<VisitRecordDisplay visits={visitWithoutPurpose} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.queryByText("訪問目的")).not.toBeInTheDocument();
+    });
+
+    it("should not display result section when null", () => {
+      const visitWithoutResult: VisitRecord[] = [
+        {
+          visit_id: 1,
+          customer_id: 1,
+          customer_name: "テスト会社",
+          visit_time: "10:00",
+          visit_purpose: "テスト目的",
+          visit_content: "テスト内容",
+          visit_result: null,
+        },
+      ];
+
+      render(<VisitRecordDisplay visits={visitWithoutResult} />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.queryByText("訪問結果")).not.toBeInTheDocument();
+    });
+
+    it("should not display time when null", () => {
+      const visitWithoutTime: VisitRecord[] = [
+        {
+          visit_id: 1,
+          customer_id: 1,
+          customer_name: "テスト会社",
+          visit_time: null,
+          visit_purpose: null,
+          visit_content: "テスト内容",
+          visit_result: null,
+        },
+      ];
+
+      render(<VisitRecordDisplay visits={visitWithoutTime} />, {
+        user: mockMemberUser,
+      });
+
+      // 時間のアイコンを含む要素が存在しないことを確認
+      expect(screen.queryByText(/^\d{2}:\d{2}$/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have article role for each visit record", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      const articles = screen.getAllByRole("article");
+      expect(articles).toHaveLength(2);
+    });
+
+    it("should have accessible labels for visit records", () => {
+      render(<VisitRecordDisplay visits={mockVisits} />, {
+        user: mockMemberUser,
+      });
+
+      expect(
+        screen.getByRole("article", { name: /訪問記録 1: 株式会社ABC/ })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("article", { name: /訪問記録 2: 株式会社XYZ/ })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/reports/components/VisitRecordDisplay.tsx
+++ b/src/features/reports/components/VisitRecordDisplay.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Building2, Clock, FileText, Target, CheckCircle } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+import type { VisitRecord } from "../types";
+
+interface VisitRecordDisplayProps {
+  visits: VisitRecord[];
+}
+
+/**
+ * 訪問記録表示コンポーネント
+ * 訪問記録一覧を表示
+ */
+export function VisitRecordDisplay({ visits }: VisitRecordDisplayProps) {
+  if (visits.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">訪問記録</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            訪問記録はありません。
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">訪問記録</CardTitle>
+        <CardDescription>{visits.length}件の訪問</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {visits.map((visit, index) => (
+            <div
+              key={visit.visit_id}
+              className="rounded-lg border p-4"
+              role="article"
+              aria-label={`訪問記録 ${index + 1}: ${visit.customer_name}`}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Building2
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <span className="font-medium">{visit.customer_name}</span>
+                </div>
+                {visit.visit_time && (
+                  <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                    <Clock className="h-3 w-3" aria-hidden="true" />
+                    <span>{visit.visit_time}</span>
+                  </div>
+                )}
+              </div>
+
+              <dl className="grid gap-3 text-sm">
+                {visit.visit_purpose && (
+                  <div>
+                    <dt className="flex items-center gap-1 font-medium text-muted-foreground">
+                      <Target className="h-3 w-3" aria-hidden="true" />
+                      訪問目的
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-wrap">
+                      {visit.visit_purpose}
+                    </dd>
+                  </div>
+                )}
+
+                <div>
+                  <dt className="flex items-center gap-1 font-medium text-muted-foreground">
+                    <FileText className="h-3 w-3" aria-hidden="true" />
+                    訪問内容
+                  </dt>
+                  <dd className="mt-1 whitespace-pre-wrap">
+                    {visit.visit_content}
+                  </dd>
+                </div>
+
+                {visit.visit_result && (
+                  <div>
+                    <dt className="flex items-center gap-1 font-medium text-muted-foreground">
+                      <CheckCircle className="h-3 w-3" aria-hidden="true" />
+                      訪問結果
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-wrap">
+                      {visit.visit_result}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reports/components/index.ts
+++ b/src/features/reports/components/index.ts
@@ -1,8 +1,13 @@
+export { CommentForm } from "./CommentForm";
+export { CommentList } from "./CommentList";
+export { ReportBasicInfo } from "./ReportBasicInfo";
+export { ReportDetailView } from "./ReportDetail";
 export { ReportForm } from "./ReportForm";
 export { ReportsList } from "./ReportsList";
 export { ReportsListSkeleton } from "./ReportsListSkeleton";
 export { ReportsSearchForm } from "./ReportsSearchForm";
 export { ReportsTable } from "./ReportsTable";
 export { ReportStatusBadge } from "./ReportStatusBadge";
+export { VisitRecordDisplay } from "./VisitRecordDisplay";
 export { VisitRecordItem } from "./VisitRecordItem";
 export { VisitRecordList } from "./VisitRecordList";

--- a/src/features/reports/types.ts
+++ b/src/features/reports/types.ts
@@ -209,3 +209,41 @@ export interface CustomersOptionsResponse {
   };
   message?: string;
 }
+
+/**
+ * ステータス更新APIレスポンス
+ */
+export interface UpdateStatusResponse {
+  success: boolean;
+  data: {
+    report_id: number;
+    status: ReportStatusType;
+    status_label: string;
+    updated_at: string;
+  };
+  message?: string;
+}
+
+/**
+ * コメント作成APIレスポンス
+ */
+export interface CreateCommentResponse {
+  success: boolean;
+  data: {
+    comment_id: number;
+    report_id: number;
+    created_at: string;
+  };
+  message?: string;
+}
+
+/**
+ * コメント削除APIレスポンス
+ */
+export interface DeleteCommentResponse {
+  success: boolean;
+  data: {
+    comment_id: number;
+  };
+  message?: string;
+}


### PR DESCRIPTION
## Summary

- 日報詳細画面 (`/reports/[id]`) を実装
- 日報の基本情報、訪問記録、コメントを表示
- 権限に応じたUI表示制御（編集ボタン、確認ボタン、コメント投稿フォーム）
- コメントの投稿・削除機能
- ステータス更新機能（上長のみ）

## 実装内容

### ページ
- `src/app/reports/[id]/page.tsx` - 日報詳細ページ

### コンポーネント
- `ReportBasicInfo` - 日報基本情報表示
- `VisitRecordDisplay` - 訪問記録表示
- `CommentList` - コメント一覧・削除
- `CommentForm` - コメント投稿フォーム（上長のみ）
- `ReportDetail` - 詳細画面メインコンポーネント

### API関数
- `updateReportStatus()` - ステータス更新
- `createComment()` - コメント作成
- `deleteComment()` - コメント削除

### テスト
- 71件のテストケース追加
- 全654テストがパス

## Test plan
- [x] npm run test:run - 654テストがパス
- [x] npm run lint - エラーなし
- [x] npm run type-check - エラーなし

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)