### PR TITLE
feat: Issue #6 共通コンポーネントの実装

### DIFF
--- a/src/components/common/ConfirmDialog.test.tsx
+++ b/src/components/common/ConfirmDialog.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen, waitFor } from "@/test/test-utils";
+
+import { ConfirmDialog, useUnsavedChangesDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    title: "確認",
+    description: "この操作を実行しますか？",
+    onConfirm: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render dialog when open is true", () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "確認" })).toBeInTheDocument();
+      expect(screen.getByText("この操作を実行しますか？")).toBeInTheDocument();
+    });
+
+    it("should not render dialog when open is false", () => {
+      render(<ConfirmDialog {...defaultProps} open={false} />);
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should render default button labels", () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole("button", { name: "確認" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "キャンセル" })
+      ).toBeInTheDocument();
+    });
+
+    it("should render custom button labels", () => {
+      render(
+        <ConfirmDialog
+          {...defaultProps}
+          confirmLabel="削除する"
+          cancelLabel="やめる"
+        />
+      );
+
+      expect(
+        screen.getByRole("button", { name: "削除する" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "やめる" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("variants", () => {
+    it("should render destructive variant with destructive button style", () => {
+      render(
+        <ConfirmDialog
+          {...defaultProps}
+          variant="destructive"
+          confirmLabel="削除"
+        />
+      );
+
+      const confirmButton = screen.getByRole("button", { name: "削除" });
+      // Check if the button has destructive class
+      expect(confirmButton).toHaveClass("bg-destructive");
+    });
+
+    it("should render default variant with default button style", () => {
+      render(<ConfirmDialog {...defaultProps} variant="default" />);
+
+      const confirmButton = screen.getByRole("button", { name: "確認" });
+      // Check if the button has primary class
+      expect(confirmButton).toHaveClass("bg-primary");
+    });
+  });
+
+  describe("user interactions", () => {
+    it("should call onConfirm and close dialog when confirm button is clicked", async () => {
+      const onConfirm = vi.fn();
+      const onOpenChange = vi.fn();
+      const { user } = render(
+        <ConfirmDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onOpenChange={onOpenChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "確認" }));
+
+      await waitFor(() => {
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("should call onCancel and close dialog when cancel button is clicked", async () => {
+      const onCancel = vi.fn();
+      const onOpenChange = vi.fn();
+      const { user } = render(
+        <ConfirmDialog
+          {...defaultProps}
+          onCancel={onCancel}
+          onOpenChange={onOpenChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("should close dialog when cancel button is clicked without onCancel", async () => {
+      const onOpenChange = vi.fn();
+      const { user } = render(
+        <ConfirmDialog {...defaultProps} onOpenChange={onOpenChange} />
+      );
+
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("async onConfirm", () => {
+    it("should show loading state during async onConfirm", async () => {
+      const asyncConfirm = vi.fn(
+        (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+      const { user } = render(
+        <ConfirmDialog {...defaultProps} onConfirm={asyncConfirm} />
+      );
+
+      await user.click(screen.getByRole("button", { name: "確認" }));
+
+      expect(screen.getByText("処理中...")).toBeInTheDocument();
+    });
+
+    it("should disable buttons during async processing", async () => {
+      const asyncConfirm = vi.fn(
+        (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 100))
+      );
+      const { user } = render(
+        <ConfirmDialog {...defaultProps} onConfirm={asyncConfirm} />
+      );
+
+      await user.click(screen.getByRole("button", { name: "確認" }));
+
+      expect(screen.getByRole("button", { name: "処理中..." })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+    });
+  });
+
+  describe("isLoading prop", () => {
+    it("should show loading state when isLoading is true", () => {
+      render(<ConfirmDialog {...defaultProps} isLoading={true} />);
+
+      expect(screen.getByText("処理中...")).toBeInTheDocument();
+    });
+
+    it("should disable buttons when isLoading is true", () => {
+      render(<ConfirmDialog {...defaultProps} isLoading={true} />);
+
+      expect(screen.getByRole("button", { name: "処理中..." })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+    });
+  });
+});
+
+describe("useUnsavedChangesDialog", () => {
+  function TestComponent({
+    onNavigate,
+  }: {
+    onNavigate: (confirmed: boolean) => void;
+  }) {
+    const { confirmNavigation, UnsavedDialog } = useUnsavedChangesDialog();
+
+    const handleClick = async () => {
+      const confirmed = await confirmNavigation();
+      onNavigate(confirmed);
+    };
+
+    return (
+      <>
+        <button onClick={handleClick}>Navigate</button>
+        <UnsavedDialog />
+      </>
+    );
+  }
+
+  it("should show unsaved changes dialog when confirmNavigation is called", async () => {
+    const onNavigate = vi.fn();
+    const { user } = render(<TestComponent onNavigate={onNavigate} />);
+
+    await user.click(screen.getByRole("button", { name: "Navigate" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByText("保存されていない変更があります")
+    ).toBeInTheDocument();
+  });
+
+  it("should resolve true when user confirms navigation", async () => {
+    const onNavigate = vi.fn();
+    const { user } = render(<TestComponent onNavigate={onNavigate} />);
+
+    await user.click(screen.getByRole("button", { name: "Navigate" }));
+    await user.click(
+      screen.getByRole("button", { name: "このページを離れる" })
+    );
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("should resolve false when user cancels navigation", async () => {
+    const onNavigate = vi.fn();
+    const { user } = render(<TestComponent onNavigate={onNavigate} />);
+
+    await user.click(screen.getByRole("button", { name: "Navigate" }));
+    await user.click(
+      screen.getByRole("button", { name: "このページに留まる" })
+    );
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("should close dialog after confirmation", async () => {
+    const onNavigate = vi.fn();
+    const { user } = render(<TestComponent onNavigate={onNavigate} />);
+
+    await user.click(screen.getByRole("button", { name: "Navigate" }));
+    await user.click(
+      screen.getByRole("button", { name: "このページを離れる" })
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type ConfirmDialogVariant = "default" | "destructive" | "warning";
+
+export interface ConfirmDialogProps {
+  /** ダイアログの開閉状態 */
+  open: boolean;
+  /** ダイアログを閉じるコールバック */
+  onOpenChange: (open: boolean) => void;
+  /** ダイアログのタイトル */
+  title: string;
+  /** ダイアログの説明文 */
+  description: string;
+  /** 確認ボタンのテキスト */
+  confirmLabel?: string;
+  /** キャンセルボタンのテキスト */
+  cancelLabel?: string;
+  /** 確認ボタンクリック時のコールバック */
+  onConfirm: () => void | Promise<void>;
+  /** キャンセルボタンクリック時のコールバック */
+  onCancel?: () => void;
+  /** ダイアログの種類（default: 通常, destructive: 削除, warning: 警告） */
+  variant?: ConfirmDialogVariant;
+  /** 確認処理中かどうか */
+  isLoading?: boolean;
+}
+
+/**
+ * 確認ダイアログコンポーネント
+ *
+ * 削除確認や画面遷移確認など、ユーザーに確認を求める際に使用します。
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ *
+ * <ConfirmDialog
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   title="削除の確認"
+ *   description="このデータを削除してもよろしいですか？この操作は取り消せません。"
+ *   confirmLabel="削除する"
+ *   variant="destructive"
+ *   onConfirm={handleDelete}
+ * />
+ * ```
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "確認",
+  cancelLabel = "キャンセル",
+  onConfirm,
+  onCancel,
+  variant = "default",
+  isLoading = false,
+}: ConfirmDialogProps) {
+  const [isPending, setIsPending] = React.useState(false);
+
+  const handleConfirm = async () => {
+    setIsPending(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (onCancel) {
+      onCancel();
+    }
+    onOpenChange(false);
+  };
+
+  const isProcessing = isLoading || isPending;
+
+  // variant に応じたボタンスタイル
+  const confirmButtonVariant =
+    variant === "destructive" ? "destructive" : "default";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-[425px]"
+        onInteractOutside={(e) => {
+          // 処理中は外側クリックでの閉じを防止
+          if (isProcessing) {
+            e.preventDefault();
+          }
+        }}
+        onEscapeKeyDown={(e) => {
+          // 処理中はEscキーでの閉じを防止
+          if (isProcessing) {
+            e.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isProcessing}
+            >
+              {cancelLabel}
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            variant={confirmButtonVariant}
+            onClick={handleConfirm}
+            disabled={isProcessing}
+          >
+            {isProcessing ? "処理中..." : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * 未保存データの確認ダイアログ用のカスタムフック
+ *
+ * @example
+ * ```tsx
+ * const { showUnsavedDialog, confirmNavigation, UnsavedDialog } = useUnsavedChangesDialog();
+ *
+ * const handleNavigation = async (path: string) => {
+ *   if (hasUnsavedChanges) {
+ *     const confirmed = await confirmNavigation();
+ *     if (!confirmed) return;
+ *   }
+ *   router.push(path);
+ * };
+ *
+ * return (
+ *   <>
+ *     <button onClick={() => handleNavigation('/other')}>Move</button>
+ *     <UnsavedDialog />
+ *   </>
+ * );
+ * ```
+ */
+export function useUnsavedChangesDialog() {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const confirmNavigation = React.useCallback((): Promise<boolean> => {
+    setIsOpen(true);
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  const handleConfirm = React.useCallback(() => {
+    resolverRef.current?.(true);
+    resolverRef.current = null;
+    setIsOpen(false);
+  }, []);
+
+  const handleCancel = React.useCallback(() => {
+    resolverRef.current?.(false);
+    resolverRef.current = null;
+    setIsOpen(false);
+  }, []);
+
+  const UnsavedDialog = React.useCallback(
+    () => (
+      <ConfirmDialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCancel();
+          }
+        }}
+        title="保存されていない変更があります"
+        description="このページを離れると、入力した内容が失われます。本当にこのページを離れますか？"
+        confirmLabel="このページを離れる"
+        cancelLabel="このページに留まる"
+        variant="warning"
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    ),
+    [isOpen, handleConfirm, handleCancel]
+  );
+
+  return {
+    showUnsavedDialog: isOpen,
+    confirmNavigation,
+    UnsavedDialog,
+  };
+}

--- a/src/components/common/FormErrorMessage.test.tsx
+++ b/src/components/common/FormErrorMessage.test.tsx
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@/test/test-utils";
+
+import {
+  FormSummaryError,
+  FieldError,
+  FormFieldWrapper,
+  getErrorInputClassName,
+} from "./FormErrorMessage";
+
+describe("FormSummaryError", () => {
+  describe("rendering", () => {
+    it("should not render when errors array is empty", () => {
+      render(<FormSummaryError errors={[]} />);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("should render when there are errors", () => {
+      const errors = [{ message: "エラーが発生しました" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("should render default title", () => {
+      const errors = [{ message: "エラーが発生しました" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(
+        screen.getByText("入力内容にエラーがあります")
+      ).toBeInTheDocument();
+    });
+
+    it("should render custom title", () => {
+      const errors = [{ message: "エラーが発生しました" }];
+      render(<FormSummaryError errors={errors} title="バリデーションエラー" />);
+
+      expect(screen.getByText("バリデーションエラー")).toBeInTheDocument();
+    });
+
+    it("should render all error messages", () => {
+      const errors = [
+        { field: "email", message: "メールアドレスは必須です" },
+        { field: "password", message: "パスワードは8文字以上必要です" },
+        { message: "入力内容を確認してください" },
+      ];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.getByText(/メールアドレスは必須です/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/パスワードは8文字以上必要です/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("入力内容を確認してください")
+      ).toBeInTheDocument();
+    });
+
+    it("should render field name with error message when field is provided", () => {
+      const errors = [{ field: "email", message: "メールアドレスは必須です" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.getByText("email:")).toBeInTheDocument();
+    });
+
+    it("should not render field name when field is not provided", () => {
+      const errors = [{ message: "一般的なエラー" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.queryByText(/:/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("dismissible", () => {
+    it("should not show dismiss button by default", () => {
+      const errors = [{ message: "エラー" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(
+        screen.queryByRole("button", { name: "閉じる" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show dismiss button when dismissible is true", () => {
+      const errors = [{ message: "エラー" }];
+      render(<FormSummaryError errors={errors} dismissible={true} />);
+
+      expect(
+        screen.getByRole("button", { name: "閉じる" })
+      ).toBeInTheDocument();
+    });
+
+    it("should call onDismiss when dismiss button is clicked", async () => {
+      const errors = [{ message: "エラー" }];
+      const onDismiss = vi.fn();
+      const { user } = render(
+        <FormSummaryError
+          errors={errors}
+          dismissible={true}
+          onDismiss={onDismiss}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "閉じる" }));
+
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have role alert", () => {
+      const errors = [{ message: "エラー" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("should have aria-live assertive", () => {
+      const errors = [{ message: "エラー" }];
+      render(<FormSummaryError errors={errors} />);
+
+      expect(screen.getByRole("alert")).toHaveAttribute(
+        "aria-live",
+        "assertive"
+      );
+    });
+  });
+});
+
+describe("FieldError", () => {
+  describe("rendering", () => {
+    it("should not render when message is undefined", () => {
+      const { container } = render(<FieldError />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should not render when message is empty string", () => {
+      const { container } = render(<FieldError message="" />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should render error message", () => {
+      render(<FieldError message="このフィールドは必須です" />);
+
+      expect(screen.getByText("このフィールドは必須です")).toBeInTheDocument();
+    });
+
+    it("should apply custom className", () => {
+      render(<FieldError message="エラー" className="custom-class" />);
+
+      expect(screen.getByText("エラー")).toHaveClass("custom-class");
+    });
+
+    it("should apply id for aria-describedby", () => {
+      render(<FieldError message="エラー" id="email-error" />);
+
+      expect(screen.getByText("エラー")).toHaveAttribute("id", "email-error");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have role alert", () => {
+      render(<FieldError message="エラー" />);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("FormFieldWrapper", () => {
+  describe("rendering", () => {
+    it("should render label with htmlFor", () => {
+      render(
+        <FormFieldWrapper label="メールアドレス" htmlFor="email">
+          <input id="email" type="email" />
+        </FormFieldWrapper>
+      );
+
+      const label = screen.getByText("メールアドレス");
+      expect(label).toHaveAttribute("for", "email");
+    });
+
+    it("should render children", () => {
+      render(
+        <FormFieldWrapper label="名前" htmlFor="name">
+          <input id="name" type="text" placeholder="名前を入力" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.getByPlaceholderText("名前を入力")).toBeInTheDocument();
+    });
+
+    it("should show required indicator when required is true", () => {
+      render(
+        <FormFieldWrapper label="メール" htmlFor="email" required>
+          <input id="email" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.getByText("*")).toBeInTheDocument();
+      expect(screen.getByText("（必須）")).toBeInTheDocument();
+    });
+
+    it("should not show required indicator when required is false", () => {
+      render(
+        <FormFieldWrapper label="メール" htmlFor="email">
+          <input id="email" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.queryByText("*")).not.toBeInTheDocument();
+    });
+
+    it("should show help text when provided", () => {
+      render(
+        <FormFieldWrapper
+          label="パスワード"
+          htmlFor="password"
+          helpText="8文字以上"
+        >
+          <input id="password" type="password" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.getByText("8文字以上")).toBeInTheDocument();
+    });
+
+    it("should not show help text when there is an error", () => {
+      render(
+        <FormFieldWrapper
+          label="パスワード"
+          htmlFor="password"
+          helpText="8文字以上"
+          error="パスワードが短すぎます"
+        >
+          <input id="password" type="password" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.queryByText("8文字以上")).not.toBeInTheDocument();
+      expect(screen.getByText("パスワードが短すぎます")).toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("should show error message when error is provided", () => {
+      render(
+        <FormFieldWrapper
+          label="Email"
+          htmlFor="email"
+          error="無効なメールアドレスです"
+        >
+          <input id="email" type="email" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.getByText("無効なメールアドレスです")).toBeInTheDocument();
+    });
+
+    it("should add error styling to input when error is provided", () => {
+      render(
+        <FormFieldWrapper label="Email" htmlFor="email" error="エラー">
+          <input id="email" type="email" className="base-class" />
+        </FormFieldWrapper>
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("border-destructive");
+    });
+
+    it("should set aria-invalid on input when error is provided", () => {
+      render(
+        <FormFieldWrapper label="Email" htmlFor="email" error="エラー">
+          <input id="email" type="email" />
+        </FormFieldWrapper>
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("should set aria-describedby on input pointing to error", () => {
+      render(
+        <FormFieldWrapper label="Email" htmlFor="email" error="エラー">
+          <input id="email" type="email" />
+        </FormFieldWrapper>
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "email-error");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should set aria-describedby pointing to help text when no error", () => {
+      render(
+        <FormFieldWrapper
+          label="パスワード"
+          htmlFor="password"
+          helpText="ヘルプ"
+        >
+          <input id="password" type="text" />
+        </FormFieldWrapper>
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "password-help");
+    });
+
+    it("should set aria-describedby to error only when there is an error", () => {
+      render(
+        <FormFieldWrapper
+          label="パスワード"
+          htmlFor="password"
+          helpText="8文字以上"
+          error="パスワードが短すぎます"
+        >
+          <input id="password" type="text" />
+        </FormFieldWrapper>
+      );
+
+      // When there's an error, help text is hidden, so only error should be in describedby
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "password-error");
+    });
+
+    it("should have sr-only text for required fields", () => {
+      render(
+        <FormFieldWrapper label="Email" htmlFor="email" required>
+          <input id="email" type="email" />
+        </FormFieldWrapper>
+      );
+
+      expect(screen.getByText("（必須）")).toHaveClass("sr-only");
+    });
+  });
+});
+
+describe("getErrorInputClassName", () => {
+  it("should return error classes when hasError is true", () => {
+    const className = getErrorInputClassName(true);
+
+    expect(className).toBe("border-destructive focus-visible:ring-destructive");
+  });
+
+  it("should return empty string when hasError is false", () => {
+    const className = getErrorInputClassName(false);
+
+    expect(className).toBe("");
+  });
+});

--- a/src/components/common/FormErrorMessage.tsx
+++ b/src/components/common/FormErrorMessage.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { AlertCircle, XCircle } from "lucide-react";
+import * as React from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+export interface FormError {
+  /** エラーが発生したフィールド名 */
+  field?: string;
+  /** エラーメッセージ */
+  message: string;
+}
+
+export interface FormSummaryErrorProps {
+  /** エラーのリスト */
+  errors: FormError[];
+  /** タイトル */
+  title?: string;
+  /** 追加のクラス名 */
+  className?: string;
+  /** 閉じるボタンを表示するか */
+  dismissible?: boolean;
+  /** 閉じるボタンクリック時のコールバック */
+  onDismiss?: () => void;
+}
+
+/**
+ * フォームサマリーエラー（画面上部に表示）
+ *
+ * フォーム送信時のバリデーションエラーを一覧表示します。
+ *
+ * @example
+ * ```tsx
+ * const errors = [
+ *   { field: "email", message: "メールアドレスの形式が正しくありません" },
+ *   { field: "password", message: "パスワードは8文字以上必要です" },
+ * ];
+ *
+ * <FormSummaryError
+ *   errors={errors}
+ *   title="入力内容にエラーがあります"
+ * />
+ * ```
+ */
+export function FormSummaryError({
+  errors,
+  title = "入力内容にエラーがあります",
+  className,
+  dismissible = false,
+  onDismiss,
+}: FormSummaryErrorProps) {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="destructive"
+      className={cn("relative", className)}
+      role="alert"
+      aria-live="assertive"
+    >
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          {errors.map((error, index) => (
+            <li key={`${error.field ?? "error"}-${index}`}>
+              {error.field && (
+                <span className="font-medium">{error.field}: </span>
+              )}
+              {error.message}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+      {dismissible && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="absolute right-3 top-3 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          aria-label="閉じる"
+        >
+          <XCircle className="h-4 w-4" />
+        </button>
+      )}
+    </Alert>
+  );
+}
+
+export interface FieldErrorProps {
+  /** エラーメッセージ */
+  message?: string;
+  /** 追加のクラス名 */
+  className?: string;
+  /** エラーのID（aria-describedby用） */
+  id?: string;
+}
+
+/**
+ * フィールドエラー（入力項目下に表示）
+ *
+ * 個別の入力フィールドのエラーメッセージを表示します。
+ *
+ * @example
+ * ```tsx
+ * <div>
+ *   <Label htmlFor="email">メールアドレス</Label>
+ *   <Input
+ *     id="email"
+ *     aria-invalid={!!errors.email}
+ *     aria-describedby="email-error"
+ *     className={errors.email ? "border-destructive" : ""}
+ *   />
+ *   <FieldError id="email-error" message={errors.email} />
+ * </div>
+ * ```
+ */
+export function FieldError({ message, className, id }: FieldErrorProps) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p
+      id={id}
+      className={cn("mt-1 text-sm text-destructive", className)}
+      role="alert"
+    >
+      {message}
+    </p>
+  );
+}
+
+export interface FormFieldWrapperProps {
+  /** ラベル */
+  label: string;
+  /** フィールドID */
+  htmlFor: string;
+  /** エラーメッセージ */
+  error?: string;
+  /** 必須フィールドかどうか */
+  required?: boolean;
+  /** ヘルプテキスト */
+  helpText?: string;
+  /** 追加のクラス名 */
+  className?: string;
+  /** 子要素（入力フィールド） */
+  children: React.ReactNode;
+}
+
+/**
+ * フォームフィールドラッパー
+ *
+ * ラベル、入力フィールド、エラーメッセージ、ヘルプテキストをまとめて扱うラッパーコンポーネント。
+ * エラー時には入力フィールドに赤枠が適用されます。
+ *
+ * @example
+ * ```tsx
+ * <FormFieldWrapper
+ *   label="メールアドレス"
+ *   htmlFor="email"
+ *   error={errors.email}
+ *   required
+ * >
+ *   <Input id="email" type="email" {...register("email")} />
+ * </FormFieldWrapper>
+ * ```
+ */
+export function FormFieldWrapper({
+  label,
+  htmlFor,
+  error,
+  required = false,
+  helpText,
+  className,
+  children,
+}: FormFieldWrapperProps) {
+  const errorId = `${htmlFor}-error`;
+  const helpId = `${htmlFor}-help`;
+  const hasError = !!error;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <label
+        htmlFor={htmlFor}
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >
+        {label}
+        {required && (
+          <span className="ml-1 text-destructive" aria-hidden="true">
+            *
+          </span>
+        )}
+        {required && <span className="sr-only">（必須）</span>}
+      </label>
+
+      {/* 子要素に適切なaria属性を追加 */}
+      {React.isValidElement<React.HTMLAttributes<HTMLElement>>(children)
+        ? React.cloneElement(children, {
+            "aria-invalid": hasError ? true : undefined,
+            "aria-describedby":
+              [
+                hasError ? errorId : null,
+                // エラーがない場合のみヘルプテキストを参照
+                !hasError && helpText ? helpId : null,
+              ]
+                .filter(Boolean)
+                .join(" ") || undefined,
+            className: cn(
+              children.props.className,
+              hasError && "border-destructive focus-visible:ring-destructive"
+            ),
+          })
+        : children}
+
+      {helpText && !hasError && (
+        <p id={helpId} className="text-sm text-muted-foreground">
+          {helpText}
+        </p>
+      )}
+
+      {error && <FieldError id={errorId} message={error} />}
+    </div>
+  );
+}
+
+/**
+ * 入力フィールドにエラー状態のスタイルを適用するユーティリティ
+ *
+ * @example
+ * ```tsx
+ * <Input className={getErrorInputClassName(!!errors.email)} />
+ * ```
+ */
+export function getErrorInputClassName(hasError: boolean): string {
+  return hasError ? "border-destructive focus-visible:ring-destructive" : "";
+}

--- a/src/components/common/Pagination.test.tsx
+++ b/src/components/common/Pagination.test.tsx
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen, waitFor } from "@/test/test-utils";
+
+import { Pagination } from "./Pagination";
+
+describe("Pagination", () => {
+  const defaultProps = {
+    currentPage: 1,
+    lastPage: 5,
+    total: 100,
+    perPage: 20,
+    onPageChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render pagination info correctly", () => {
+      render(<Pagination {...defaultProps} />);
+
+      expect(screen.getByText(/全100件中/)).toBeInTheDocument();
+      expect(screen.getByText(/1〜20件を表示/)).toBeInTheDocument();
+    });
+
+    it("should format large numbers with locale separator", () => {
+      render(<Pagination {...defaultProps} total={1234567} currentPage={1} />);
+
+      expect(screen.getByText(/全1,234,567件中/)).toBeInTheDocument();
+    });
+
+    it("should show correct range for middle page", () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      expect(screen.getByText(/41〜60件を表示/)).toBeInTheDocument();
+    });
+
+    it("should show correct range for last page with partial items", () => {
+      render(
+        <Pagination
+          {...defaultProps}
+          currentPage={5}
+          lastPage={5}
+          total={95}
+          perPage={20}
+        />
+      );
+
+      expect(screen.getByText(/81〜95件を表示/)).toBeInTheDocument();
+    });
+
+    it("should show 0 items when total is 0", () => {
+      render(
+        <Pagination
+          {...defaultProps}
+          currentPage={1}
+          lastPage={0}
+          total={0}
+          perPage={20}
+        />
+      );
+
+      expect(screen.getByText(/全0件中/)).toBeInTheDocument();
+      expect(screen.getByText(/0〜0件を表示/)).toBeInTheDocument();
+    });
+  });
+
+  describe("navigation buttons", () => {
+    it("should disable first and prev buttons on first page", () => {
+      render(<Pagination {...defaultProps} currentPage={1} />);
+
+      expect(
+        screen.getByRole("button", { name: "最初のページへ" })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "前のページへ" })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "次のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "最後のページへ" })
+      ).not.toBeDisabled();
+    });
+
+    it("should disable next and last buttons on last page", () => {
+      render(<Pagination {...defaultProps} currentPage={5} lastPage={5} />);
+
+      expect(
+        screen.getByRole("button", { name: "最初のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "前のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "次のページへ" })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "最後のページへ" })
+      ).toBeDisabled();
+    });
+
+    it("should enable all buttons on middle page", () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      expect(
+        screen.getByRole("button", { name: "最初のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "前のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "次のページへ" })
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "最後のページへ" })
+      ).not.toBeDisabled();
+    });
+
+    it("should call onPageChange with 1 when clicking first button", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={3}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "最初のページへ" }));
+
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it("should call onPageChange with previous page when clicking prev button", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={3}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "前のページへ" }));
+
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it("should call onPageChange with next page when clicking next button", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={3}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "次のページへ" }));
+
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it("should call onPageChange with last page when clicking last button", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={3}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "最後のページへ" }));
+
+      expect(onPageChange).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe("direct page input", () => {
+    it("should render page input field when allowDirectInput is true", () => {
+      render(<Pagination {...defaultProps} allowDirectInput={true} />);
+
+      expect(
+        screen.getByRole("textbox", { name: "ページ番号を入力" })
+      ).toBeInTheDocument();
+    });
+
+    it("should not render page input field when allowDirectInput is false", () => {
+      render(<Pagination {...defaultProps} allowDirectInput={false} />);
+
+      expect(
+        screen.queryByRole("textbox", { name: "ページ番号を入力" })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("1 / 5")).toBeInTheDocument();
+    });
+
+    it("should show current page in input field", () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      expect(input).toHaveValue("3");
+    });
+
+    it("should call onPageChange when entering valid page number and pressing Enter", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={1}
+          onPageChange={onPageChange}
+        />
+      );
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "3");
+      await user.keyboard("{Enter}");
+
+      expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it("should call onPageChange when entering valid page number and blurring", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={1}
+          onPageChange={onPageChange}
+        />
+      );
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "4");
+      await user.tab();
+
+      await waitFor(() => {
+        expect(onPageChange).toHaveBeenCalledWith(4);
+      });
+    });
+
+    it("should revert to current page when entering invalid page number", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={2}
+          onPageChange={onPageChange}
+        />
+      );
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "99");
+      await user.keyboard("{Enter}");
+
+      expect(onPageChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue("2");
+    });
+
+    it("should revert to current page when entering zero", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={2}
+          onPageChange={onPageChange}
+        />
+      );
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "0");
+      await user.keyboard("{Enter}");
+
+      expect(onPageChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue("2");
+    });
+
+    it("should not call onPageChange when entering same page number", async () => {
+      const onPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          currentPage={3}
+          onPageChange={onPageChange}
+        />
+      );
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "3");
+      await user.keyboard("{Enter}");
+
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it("should only accept numeric input", async () => {
+      const { user } = render(<Pagination {...defaultProps} currentPage={1} />);
+
+      const input = screen.getByRole("textbox", { name: "ページ番号を入力" });
+      await user.clear(input);
+      await user.type(input, "abc");
+
+      expect(input).toHaveValue("");
+    });
+  });
+
+  describe("per page selector", () => {
+    it("should not render per page selector when onPerPageChange is not provided", () => {
+      render(<Pagination {...defaultProps} />);
+
+      expect(screen.queryByText("表示件数:")).not.toBeInTheDocument();
+    });
+
+    it("should render per page selector when onPerPageChange is provided", () => {
+      const onPerPageChange = vi.fn();
+      render(
+        <Pagination {...defaultProps} onPerPageChange={onPerPageChange} />
+      );
+
+      expect(screen.getByText("表示件数:")).toBeInTheDocument();
+    });
+
+    it("should show current per page value", () => {
+      const onPerPageChange = vi.fn();
+      render(
+        <Pagination
+          {...defaultProps}
+          perPage={20}
+          onPerPageChange={onPerPageChange}
+        />
+      );
+
+      expect(
+        screen.getByRole("combobox", { name: "1ページあたりの表示件数" })
+      ).toHaveTextContent("20件");
+    });
+
+    it("should call onPerPageChange when selecting new value", async () => {
+      const onPerPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          perPage={20}
+          onPerPageChange={onPerPageChange}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("combobox", { name: "1ページあたりの表示件数" })
+      );
+      await user.click(screen.getByRole("option", { name: "50件" }));
+
+      expect(onPerPageChange).toHaveBeenCalledWith(50);
+    });
+
+    it("should render custom per page options", async () => {
+      const onPerPageChange = vi.fn();
+      const { user } = render(
+        <Pagination
+          {...defaultProps}
+          perPage={25}
+          onPerPageChange={onPerPageChange}
+          perPageOptions={[25, 50, 100]}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("combobox", { name: "1ページあたりの表示件数" })
+      );
+
+      expect(screen.getByRole("option", { name: "25件" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "50件" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "100件" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have aria-live on pagination info", () => {
+      render(<Pagination {...defaultProps} />);
+
+      const info = screen.getByText(/全100件中/);
+      expect(info).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("should have proper aria-labels on all buttons", () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      expect(
+        screen.getByRole("button", { name: "最初のページへ" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "前のページへ" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "次のページへ" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "最後のページへ" })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,51 +1,216 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
+import * as React from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-interface PaginationProps {
+export interface PaginationProps {
+  /** 現在のページ番号（1始まり） */
   currentPage: number;
+  /** 最終ページ番号 */
   lastPage: number;
+  /** 総件数 */
   total: number;
+  /** 1ページあたりの表示件数 */
+  perPage: number;
+  /** ページ変更時のコールバック */
   onPageChange: (page: number) => void;
+  /** 表示件数変更時のコールバック */
+  onPerPageChange?: (perPage: number) => void;
+  /** 表示件数のオプション */
+  perPageOptions?: number[];
+  /** ページ番号直接入力を許可するかどうか */
+  allowDirectInput?: boolean;
 }
+
+const DEFAULT_PER_PAGE_OPTIONS = [10, 20, 50];
 
 export function Pagination({
   currentPage,
   lastPage,
   total,
+  perPage,
   onPageChange,
+  onPerPageChange,
+  perPageOptions = DEFAULT_PER_PAGE_OPTIONS,
+  allowDirectInput = true,
 }: PaginationProps) {
+  const [inputPage, setInputPage] = React.useState<string>(
+    currentPage.toString()
+  );
+  const [isInputFocused, setIsInputFocused] = React.useState(false);
+
+  // currentPageが外部から変更された場合にinputPageを同期
+  React.useEffect(() => {
+    if (!isInputFocused) {
+      setInputPage(currentPage.toString());
+    }
+  }, [currentPage, isInputFocused]);
+
   const hasPrevPage = currentPage > 1;
   const hasNextPage = currentPage < lastPage;
 
+  // 表示範囲の計算
+  const startItem = total === 0 ? 0 : (currentPage - 1) * perPage + 1;
+  const endItem = Math.min(currentPage * perPage, total);
+
+  const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    // 数字のみ許可
+    if (value === "" || /^\d+$/.test(value)) {
+      setInputPage(value);
+    }
+  };
+
+  const handlePageInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      submitPageInput();
+    }
+  };
+
+  const handlePageInputBlur = () => {
+    setIsInputFocused(false);
+    submitPageInput();
+  };
+
+  const submitPageInput = () => {
+    const pageNum = parseInt(inputPage, 10);
+    if (!isNaN(pageNum) && pageNum >= 1 && pageNum <= lastPage) {
+      if (pageNum !== currentPage) {
+        onPageChange(pageNum);
+      }
+    } else {
+      // 無効な値の場合は現在のページに戻す
+      setInputPage(currentPage.toString());
+    }
+  };
+
+  const handlePerPageChange = (value: string) => {
+    const newPerPage = parseInt(value, 10);
+    if (onPerPageChange) {
+      onPerPageChange(newPerPage);
+    }
+  };
+
   return (
-    <div className="flex items-center justify-between">
-      <p className="text-sm text-muted-foreground">
-        全{total}件中 {currentPage}ページ / {lastPage}ページ
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      {/* 件数表示 */}
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        全{total.toLocaleString()}件中 {startItem.toLocaleString()}〜
+        {endItem.toLocaleString()}件を表示
       </p>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(currentPage - 1)}
-          disabled={!hasPrevPage}
-          aria-label="前のページ"
-        >
-          <ChevronLeft className="h-4 w-4" />
-          前へ
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(currentPage + 1)}
-          disabled={!hasNextPage}
-          aria-label="次のページ"
-        >
-          次へ
-          <ChevronRight className="h-4 w-4" />
-        </Button>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+        {/* 表示件数切り替え */}
+        {onPerPageChange && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">表示件数:</span>
+            <Select
+              value={perPage.toString()}
+              onValueChange={handlePerPageChange}
+            >
+              <SelectTrigger
+                className="w-20"
+                aria-label="1ページあたりの表示件数"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {perPageOptions.map((option) => (
+                  <SelectItem key={option} value={option.toString()}>
+                    {option}件
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {/* ページ移動 */}
+        <div className="flex items-center gap-1">
+          {/* 先頭ページへ */}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => onPageChange(1)}
+            disabled={!hasPrevPage}
+            aria-label="最初のページへ"
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+
+          {/* 前ページへ */}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={!hasPrevPage}
+            aria-label="前のページへ"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+
+          {/* ページ番号直接入力 */}
+          {allowDirectInput ? (
+            <div className="flex items-center gap-1 px-2">
+              <Input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={inputPage}
+                onChange={handlePageInputChange}
+                onKeyDown={handlePageInputKeyDown}
+                onFocus={() => setIsInputFocused(true)}
+                onBlur={handlePageInputBlur}
+                className="h-9 w-14 text-center"
+                aria-label="ページ番号を入力"
+              />
+              <span className="text-sm text-muted-foreground">
+                / {lastPage.toLocaleString()}
+              </span>
+            </div>
+          ) : (
+            <span className="px-2 text-sm">
+              {currentPage} / {lastPage}
+            </span>
+          )}
+
+          {/* 次ページへ */}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={!hasNextPage}
+            aria-label="次のページへ"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+
+          {/* 最終ページへ */}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => onPageChange(lastPage)}
+            disabled={!hasNextPage}
+            aria-label="最後のページへ"
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,21 @@
+// Pagination
+export { Pagination } from "./Pagination";
+export type { PaginationProps } from "./Pagination";
+
+// ConfirmDialog
+export { ConfirmDialog, useUnsavedChangesDialog } from "./ConfirmDialog";
+export type { ConfirmDialogProps, ConfirmDialogVariant } from "./ConfirmDialog";
+
+// FormErrorMessage
+export {
+  FormSummaryError,
+  FieldError,
+  FormFieldWrapper,
+  getErrorInputClassName,
+} from "./FormErrorMessage";
+export type {
+  FormError,
+  FormSummaryErrorProps,
+  FieldErrorProps,
+  FormFieldWrapperProps,
+} from "./FormErrorMessage";

--- a/src/features/reports/components/ReportsList.tsx
+++ b/src/features/reports/components/ReportsList.tsx
@@ -188,6 +188,7 @@ export function ReportsList() {
           currentPage={pagination.current_page}
           lastPage={pagination.last_page}
           total={pagination.total}
+          perPage={pagination.per_page}
           onPageChange={handlePageChange}
         />
       )}

--- a/src/features/sales-persons/components/SalesPersonsList.tsx
+++ b/src/features/sales-persons/components/SalesPersonsList.tsx
@@ -155,6 +155,7 @@ export function SalesPersonsList() {
           currentPage={pagination.current_page}
           lastPage={pagination.last_page}
           total={pagination.total}
+          perPage={pagination.per_page}
           onPageChange={handlePageChange}
         />
       )}

--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -1,0 +1,264 @@
+import { toast } from "sonner";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  showSuccessToast,
+  showErrorToast,
+  showWarningToast,
+  showInfoToast,
+  showPromiseToast,
+  dismissAllToasts,
+  dismissToast,
+  showApiResultToast,
+} from "./toast";
+
+// sonner の toast 関数をモック
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+describe("Toast utilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("showSuccessToast", () => {
+    it("should call toast.success with message and default duration", () => {
+      showSuccessToast("保存しました");
+
+      expect(toast.success).toHaveBeenCalledWith("保存しました", {
+        duration: 5000,
+        description: undefined,
+        action: undefined,
+      });
+    });
+
+    it("should call toast.success with custom duration", () => {
+      showSuccessToast("保存しました", { duration: 3000 });
+
+      expect(toast.success).toHaveBeenCalledWith("保存しました", {
+        duration: 3000,
+        description: undefined,
+        action: undefined,
+      });
+    });
+
+    it("should call toast.success with description", () => {
+      showSuccessToast("保存しました", {
+        description: "データが正常に保存されました",
+      });
+
+      expect(toast.success).toHaveBeenCalledWith("保存しました", {
+        duration: 5000,
+        description: "データが正常に保存されました",
+        action: undefined,
+      });
+    });
+
+    it("should call toast.success with action", () => {
+      const onClick = vi.fn();
+      showSuccessToast("保存しました", {
+        action: { label: "元に戻す", onClick },
+      });
+
+      expect(toast.success).toHaveBeenCalledWith("保存しました", {
+        duration: 5000,
+        description: undefined,
+        action: { label: "元に戻す", onClick },
+      });
+    });
+  });
+
+  describe("showErrorToast", () => {
+    it("should call toast.error with message and default duration", () => {
+      showErrorToast("エラーが発生しました");
+
+      expect(toast.error).toHaveBeenCalledWith("エラーが発生しました", {
+        duration: 5000,
+        description: undefined,
+        action: undefined,
+      });
+    });
+
+    it("should call toast.error with description", () => {
+      showErrorToast("保存に失敗しました", {
+        description: "ネットワークエラー",
+      });
+
+      expect(toast.error).toHaveBeenCalledWith("保存に失敗しました", {
+        duration: 5000,
+        description: "ネットワークエラー",
+        action: undefined,
+      });
+    });
+  });
+
+  describe("showWarningToast", () => {
+    it("should call toast.warning with message and default duration", () => {
+      showWarningToast("入力内容を確認してください");
+
+      expect(toast.warning).toHaveBeenCalledWith("入力内容を確認してください", {
+        duration: 5000,
+        description: undefined,
+        action: undefined,
+      });
+    });
+  });
+
+  describe("showInfoToast", () => {
+    it("should call toast.info with message and default duration", () => {
+      showInfoToast("新しいデータがあります");
+
+      expect(toast.info).toHaveBeenCalledWith("新しいデータがあります", {
+        duration: 5000,
+        description: undefined,
+        action: undefined,
+      });
+    });
+  });
+
+  describe("showPromiseToast", () => {
+    it("should call toast.promise with promise and messages", async () => {
+      const promise = Promise.resolve({ name: "テスト" });
+
+      showPromiseToast(promise, {
+        loading: "保存中...",
+        success: "保存しました",
+        error: "保存に失敗しました",
+      });
+
+      expect(toast.promise).toHaveBeenCalledWith(promise, {
+        loading: "保存中...",
+        success: "保存しました",
+        error: "保存に失敗しました",
+      });
+    });
+
+    it("should support callback functions for success and error messages", async () => {
+      const promise = Promise.resolve({ name: "テスト" });
+      const successFn = (data: { name: string }) =>
+        `${data.name}を保存しました`;
+      const errorFn = (err: Error) => `エラー: ${err.message}`;
+
+      showPromiseToast(promise, {
+        loading: "保存中...",
+        success: successFn,
+        error: errorFn,
+      });
+
+      expect(toast.promise).toHaveBeenCalledWith(promise, {
+        loading: "保存中...",
+        success: successFn,
+        error: errorFn,
+      });
+    });
+  });
+
+  describe("dismissAllToasts", () => {
+    it("should call toast.dismiss without arguments", () => {
+      dismissAllToasts();
+
+      expect(toast.dismiss).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("dismissToast", () => {
+    it("should call toast.dismiss with string toastId", () => {
+      dismissToast("toast-123");
+
+      expect(toast.dismiss).toHaveBeenCalledWith("toast-123");
+    });
+
+    it("should call toast.dismiss with number toastId", () => {
+      dismissToast(456);
+
+      expect(toast.dismiss).toHaveBeenCalledWith(456);
+    });
+  });
+
+  describe("showApiResultToast", () => {
+    it("should show success toast when result.success is true", () => {
+      const result = { success: true, message: "処理完了" };
+
+      showApiResultToast(result);
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "処理完了",
+        expect.any(Object)
+      );
+    });
+
+    it("should show custom success message when provided", () => {
+      const result = { success: true, message: "API成功" };
+
+      showApiResultToast(result, { successMessage: "カスタム成功メッセージ" });
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "カスタム成功メッセージ",
+        expect.any(Object)
+      );
+    });
+
+    it("should show default success message when no message in result", () => {
+      const result = { success: true };
+
+      showApiResultToast(result);
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "処理が完了しました",
+        expect.any(Object)
+      );
+    });
+
+    it("should show error toast when result.success is false", () => {
+      const result = { success: false, error: { message: "サーバーエラー" } };
+
+      showApiResultToast(result);
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "サーバーエラー",
+        expect.any(Object)
+      );
+    });
+
+    it("should show custom error message when provided", () => {
+      const result = { success: false, error: { message: "サーバーエラー" } };
+
+      showApiResultToast(result, { errorMessage: "カスタムエラーメッセージ" });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "カスタムエラーメッセージ",
+        expect.any(Object)
+      );
+    });
+
+    it("should show message from result when error object is missing", () => {
+      const result = { success: false, message: "失敗しました" };
+
+      showApiResultToast(result);
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "失敗しました",
+        expect.any(Object)
+      );
+    });
+
+    it("should show default error message when no error info in result", () => {
+      const result = { success: false };
+
+      showApiResultToast(result);
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "エラーが発生しました",
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,197 @@
+import { toast } from "sonner";
+
+/** Toast通知の自動消去時間（ミリ秒） */
+const DEFAULT_DURATION = 5000;
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface ToastOptions {
+  /** 表示時間（ミリ秒）。デフォルトは5000ms */
+  duration?: number;
+  /** 説明文 */
+  description?: string;
+  /** アクションボタン */
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+/**
+ * 成功メッセージを表示
+ *
+ * @example
+ * ```ts
+ * showSuccessToast("保存しました");
+ * showSuccessToast("登録完了", { description: "データが正常に登録されました" });
+ * ```
+ */
+export function showSuccessToast(message: string, options?: ToastOptions) {
+  toast.success(message, {
+    duration: options?.duration ?? DEFAULT_DURATION,
+    description: options?.description,
+    action: options?.action
+      ? {
+          label: options.action.label,
+          onClick: options.action.onClick,
+        }
+      : undefined,
+  });
+}
+
+/**
+ * エラーメッセージを表示
+ *
+ * @example
+ * ```ts
+ * showErrorToast("エラーが発生しました");
+ * showErrorToast("保存に失敗しました", { description: "ネットワークエラー" });
+ * ```
+ */
+export function showErrorToast(message: string, options?: ToastOptions) {
+  toast.error(message, {
+    duration: options?.duration ?? DEFAULT_DURATION,
+    description: options?.description,
+    action: options?.action
+      ? {
+          label: options.action.label,
+          onClick: options.action.onClick,
+        }
+      : undefined,
+  });
+}
+
+/**
+ * 警告メッセージを表示
+ *
+ * @example
+ * ```ts
+ * showWarningToast("入力内容を確認してください");
+ * ```
+ */
+export function showWarningToast(message: string, options?: ToastOptions) {
+  toast.warning(message, {
+    duration: options?.duration ?? DEFAULT_DURATION,
+    description: options?.description,
+    action: options?.action
+      ? {
+          label: options.action.label,
+          onClick: options.action.onClick,
+        }
+      : undefined,
+  });
+}
+
+/**
+ * 情報メッセージを表示
+ *
+ * @example
+ * ```ts
+ * showInfoToast("新しいデータがあります");
+ * ```
+ */
+export function showInfoToast(message: string, options?: ToastOptions) {
+  toast.info(message, {
+    duration: options?.duration ?? DEFAULT_DURATION,
+    description: options?.description,
+    action: options?.action
+      ? {
+          label: options.action.label,
+          onClick: options.action.onClick,
+        }
+      : undefined,
+  });
+}
+
+/**
+ * Promise の結果に応じてToastを表示
+ *
+ * @example
+ * ```ts
+ * showPromiseToast(
+ *   saveData(),
+ *   {
+ *     loading: "保存中...",
+ *     success: "保存しました",
+ *     error: "保存に失敗しました",
+ *   }
+ * );
+ *
+ * // コールバックで動的メッセージ
+ * showPromiseToast(
+ *   saveData(),
+ *   {
+ *     loading: "保存中...",
+ *     success: (data) => `${data.name}を保存しました`,
+ *     error: (err) => `エラー: ${err.message}`,
+ *   }
+ * );
+ * ```
+ */
+export function showPromiseToast<T>(
+  promise: Promise<T>,
+  messages: {
+    loading: string;
+    success: string | ((data: T) => string);
+    error: string | ((error: Error) => string);
+  }
+) {
+  return toast.promise(promise, {
+    loading: messages.loading,
+    success: messages.success,
+    error: messages.error,
+  });
+}
+
+/**
+ * 全てのToastを閉じる
+ */
+export function dismissAllToasts() {
+  toast.dismiss();
+}
+
+/**
+ * 特定のToastを閉じる
+ */
+export function dismissToast(toastId: string | number) {
+  toast.dismiss(toastId);
+}
+
+/**
+ * API レスポンスに基づいてToastを表示するユーティリティ
+ *
+ * @example
+ * ```ts
+ * const result = await fetchData();
+ * showApiResultToast(result, {
+ *   successMessage: "データを取得しました",
+ *   errorMessage: "データの取得に失敗しました",
+ * });
+ * ```
+ */
+export function showApiResultToast<
+  T extends {
+    success: boolean;
+    message?: string;
+    error?: { message?: string };
+  },
+>(
+  result: T,
+  options: {
+    successMessage?: string;
+    errorMessage?: string;
+  } = {}
+) {
+  if (result.success) {
+    showSuccessToast(
+      options.successMessage ?? result.message ?? "処理が完了しました"
+    );
+  } else {
+    showErrorToast(
+      options.errorMessage ??
+        result.error?.message ??
+        result.message ??
+        "エラーが発生しました"
+    );
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -44,3 +44,11 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }));
+
+// PointerCapture APIモック（Radix UI Select用）
+Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();
+
+// scrollIntoView モック
+Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
## Summary

- 共通コンポーネント（ページネーション、確認ダイアログ、Toast通知、エラーメッセージ表示）を実装
- 一覧画面で使用する汎用的なUIコンポーネントを提供

## 実装内容

### 1. Pagination（拡張）
- 表示件数切り替え（10/20/50件）
- ページ番号直接指定（キーボード入力対応）
- 先頭/前へ/次へ/最終ページボタン
- 総件数・現在位置の表示（「全100件中 1〜20件を表示」形式）
- アクセシビリティ対応

### 2. ConfirmDialog
- 汎用的な確認ダイアログコンポーネント
- 3種類のvariant: default, destructive, warning
- カスタマイズ可能なタイトル・メッセージ・ボタンラベル
- 非同期処理対応（ローディング状態）
- `useUnsavedChangesDialog` フック

### 3. Toast通知
- `showSuccessToast` - 成功メッセージ（緑）
- `showErrorToast` - エラーメッセージ（赤）
- `showWarningToast` - 警告メッセージ（黄）
- `showInfoToast` - 情報メッセージ
- 自動消去（デフォルト5秒）
- APIレスポンス用ユーティリティ

### 4. FormErrorMessage
- `FormSummaryError` - フォーム上部のエラー一覧
- `FieldError` - 個別フィールドのエラー
- `FormFieldWrapper` - ラベル・入力・エラーをまとめるラッパー
- エラー状態のスタイルユーティリティ

### テスト
- 98件のテストケース追加
- 全752テストがパス

## Test plan
- [x] npm run test:run - 752テストがパス
- [x] npm run lint - エラーなし
- [x] npm run type-check - エラーなし

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)