### PR TITLE
test: Issue #19 日報機能の単体テスト・結合テスト実装

### DIFF
--- a/src/app/api/v1/comments/[id]/route.test.ts
+++ b/src/app/api/v1/comments/[id]/route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * コメントAPI削除のユニットテスト
+ *
+ * テスト対象:
+ * - DELETE /api/v1/comments/{id} - コメント削除
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaCommentFindUnique = vi.fn();
+const mockPrismaCommentDelete = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    comment: {
+      findUnique: (...args: unknown[]) => mockPrismaCommentFindUnique(...args),
+      delete: (...args: unknown[]) => mockPrismaCommentDelete(...args),
+    },
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Comments API - DELETE /api/v1/comments/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/comments/${id}`, {
+      method: "DELETE",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const managerSession = {
+    user: {
+      id: 2,
+      name: "テスト上長",
+      email: "manager@example.com",
+      isManager: true,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント削除 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(managerSession);
+    });
+
+    it("自分のコメントを削除できること（UT-CMT-003）", async () => {
+      mockPrismaCommentFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 2, // 自分が投稿したコメント
+      });
+      mockPrismaCommentDelete.mockResolvedValue({ id: 1 });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.comment_id).toBe(1);
+      expect(body.message).toBe("コメントを削除しました");
+    });
+  });
+
+  describe("コメント削除 - 存在チェック", () => {
+    it("存在しないコメントを削除しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaCommentFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await DELETE(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("コメントが見つかりません");
+    });
+  });
+
+  describe("コメント削除 - 権限チェック", () => {
+    it("他人のコメントを削除しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaCommentFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 3, // 別の人が投稿したコメント
+      });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "自分が投稿したコメントのみ削除できます"
+      );
+    });
+  });
+
+  describe("コメント削除 - バリデーション", () => {
+    it("不正なIDフォーマットの場合、422エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+
+      const request = createRequest("abc");
+      const response = await DELETE(request, createContext("abc"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/src/app/api/v1/reports/[id]/comments/route.test.ts
+++ b/src/app/api/v1/reports/[id]/comments/route.test.ts
@@ -1,0 +1,348 @@
+/**
+ * コメントAPI一覧取得・新規作成のユニットテスト
+ *
+ * テスト対象:
+ * - GET /api/v1/reports/{reportId}/comments - コメント一覧取得
+ * - POST /api/v1/reports/{reportId}/comments - コメント新規作成
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaReportFindUnique = vi.fn();
+const mockPrismaCommentFindMany = vi.fn();
+const mockPrismaCommentCreate = vi.fn();
+const mockPrismaSalesPersonFindFirst = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: (...args: unknown[]) => mockPrismaReportFindUnique(...args),
+    },
+    comment: {
+      findMany: (...args: unknown[]) => mockPrismaCommentFindMany(...args),
+      create: (...args: unknown[]) => mockPrismaCommentCreate(...args),
+    },
+    salesPerson: {
+      findFirst: (...args: unknown[]) =>
+        mockPrismaSalesPersonFindFirst(...args),
+    },
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Comments API - GET /api/v1/reports/{reportId}/comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (reportId: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${reportId}/comments`, {
+      method: "GET",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント一覧取得 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("コメント一覧を取得できること", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+      });
+      mockPrismaCommentFindMany.mockResolvedValue([
+        {
+          id: 1,
+          reportId: 1,
+          salesPersonId: 2,
+          commentText: "お疲れ様です。良い成果ですね。",
+          createdAt: new Date("2024-01-15T19:00:00Z"),
+          updatedAt: new Date("2024-01-15T19:00:00Z"),
+          salesPerson: { name: "テスト上長" },
+        },
+        {
+          id: 2,
+          reportId: 1,
+          salesPersonId: 2,
+          commentText: "次回も頑張ってください。",
+          createdAt: new Date("2024-01-15T19:30:00Z"),
+          updatedAt: new Date("2024-01-15T19:30:00Z"),
+          salesPerson: { name: "テスト上長" },
+        },
+      ]);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(2);
+      expect(body.data.items[0]).toMatchObject({
+        comment_id: 1,
+        report_id: 1,
+        sales_person_id: 2,
+        sales_person_name: "テスト上長",
+        comment_text: "お疲れ様です。良い成果ですね。",
+      });
+    });
+
+    it("コメントが0件の場合、空配列を返すこと", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+      });
+      mockPrismaCommentFindMany.mockResolvedValue([]);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(0);
+    });
+  });
+
+  describe("コメント一覧取得 - 存在チェック", () => {
+    it("存在しない日報のコメントを取得しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaReportFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await GET(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント一覧取得 - 権限チェック", () => {
+    it("他人の日報のコメントを取得しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 3, name: "別のユーザー", isManager: false },
+      });
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1, // 別の人の日報
+      });
+      mockPrismaSalesPersonFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+
+    it("上長は部下の日報のコメントを取得できること", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 2, name: "テスト上長", isManager: true },
+      });
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1, // 部下の日報
+      });
+      mockPrismaSalesPersonFindFirst.mockResolvedValue({ id: 1, managerId: 2 }); // 部下である
+      mockPrismaCommentFindMany.mockResolvedValue([]);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+});
+
+describe("Comments API - POST /api/v1/reports/{reportId}/comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (reportId: string, body: unknown): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${reportId}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  const managerSession = {
+    user: {
+      id: 2,
+      name: "テスト上長",
+      email: "manager@example.com",
+      isManager: true,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1", { comment_text: "テストコメント" });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント投稿 - 正常系", () => {
+    it("上長がコメントを投稿できること（UT-CMT-001）", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1, // 部下の日報
+      });
+      mockPrismaSalesPersonFindFirst.mockResolvedValue({ id: 1, managerId: 2 }); // 部下である
+      mockPrismaCommentCreate.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        salesPersonId: 2,
+        createdAt: new Date("2024-01-15T19:00:00Z"),
+      });
+
+      const request = createRequest("1", {
+        comment_text: "お疲れ様です。良い成果ですね。",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        comment_id: 1,
+        report_id: 1,
+      });
+      expect(body.message).toBe("コメントを投稿しました");
+    });
+  });
+
+  describe("コメント投稿 - 権限チェック", () => {
+    it("一般営業担当者はコメントを投稿できないこと（UT-CMT-002）", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const request = createRequest("1", { comment_text: "テストコメント" });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("上長のみ");
+    });
+
+    it("上長でもアクセス権限のない日報にはコメントできないこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 3, // 部下でない人の日報
+      });
+      mockPrismaSalesPersonFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("1", { comment_text: "テストコメント" });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント投稿 - バリデーションエラー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(managerSession);
+    });
+
+    it("コメント内容が未入力の場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", { comment_text: "" });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("コメント内容が500文字を超える場合、バリデーションエラーになること", async () => {
+      const longComment = "あ".repeat(501);
+
+      const request = createRequest("1", { comment_text: longComment });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("コメント投稿 - 存在チェック", () => {
+    it("存在しない日報にコメントしようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaReportFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999", { comment_text: "テストコメント" });
+      const response = await POST(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/src/app/api/v1/reports/[id]/route.test.ts
+++ b/src/app/api/v1/reports/[id]/route.test.ts
@@ -1,0 +1,557 @@
+/**
+ * 日報API詳細取得・更新・削除のユニットテスト
+ *
+ * テスト対象:
+ * - GET /api/v1/reports/{id} - 日報詳細取得
+ * - PUT /api/v1/reports/{id} - 日報更新
+ * - DELETE /api/v1/reports/{id} - 日報削除
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, GET, PUT } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaFindUnique = vi.fn();
+const mockPrismaFindFirst = vi.fn();
+const mockPrismaUpdate = vi.fn();
+const mockPrismaDelete = vi.fn();
+const mockPrismaTransaction = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: (...args: unknown[]) => mockPrismaFindUnique(...args),
+      update: (...args: unknown[]) => mockPrismaUpdate(...args),
+      delete: (...args: unknown[]) => mockPrismaDelete(...args),
+    },
+    salesPerson: {
+      findFirst: (...args: unknown[]) => mockPrismaFindFirst(...args),
+    },
+    customer: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    visitRecord: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    $transaction: (...args: unknown[]) => mockPrismaTransaction(...args),
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+// テスト用データ
+const mockReportDetailData = {
+  id: 1,
+  reportDate: new Date("2024-01-15"),
+  salesPersonId: 1,
+  status: "submitted",
+  problem: "課題テスト",
+  plan: "予定テスト",
+  createdAt: new Date("2024-01-15T10:00:00Z"),
+  updatedAt: new Date("2024-01-15T18:00:00Z"),
+  salesPerson: { name: "テスト太郎" },
+  visitRecords: [
+    {
+      id: 1,
+      customerId: 1,
+      visitTime: new Date("1970-01-01T10:30:00Z"),
+      visitPurpose: "商談",
+      visitContent: "新規提案を行いました",
+      visitResult: "次回アポイント取得",
+      customer: { customerName: "株式会社テスト" },
+    },
+  ],
+  comments: [
+    {
+      id: 1,
+      salesPersonId: 2,
+      commentText: "お疲れ様です",
+      createdAt: new Date("2024-01-15T19:00:00Z"),
+      salesPerson: { name: "テスト上長" },
+    },
+  ],
+};
+
+describe("Reports API - GET /api/v1/reports/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${id}`, {
+      method: "GET",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報詳細取得 - 正常系", () => {
+    const memberSession = {
+      user: {
+        id: 1,
+        name: "テスト太郎",
+        email: "member@example.com",
+        isManager: false,
+      },
+    };
+
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("日報詳細が正しく表示されること（UT-RPT-012）", async () => {
+      mockPrismaFindUnique.mockResolvedValue(mockReportDetailData);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        report_id: 1,
+        report_date: "2024-01-15",
+        sales_person_id: 1,
+        sales_person_name: "テスト太郎",
+        status: "submitted",
+        status_label: "提出済",
+        problem: "課題テスト",
+        plan: "予定テスト",
+      });
+      expect(body.data.visits).toHaveLength(1);
+      expect(body.data.visits[0]).toMatchObject({
+        visit_id: 1,
+        customer_id: 1,
+        customer_name: "株式会社テスト",
+        visit_time: "10:30",
+        visit_content: "新規提案を行いました",
+      });
+      expect(body.data.comments).toHaveLength(1);
+      expect(body.data.comments[0]).toMatchObject({
+        comment_id: 1,
+        sales_person_name: "テスト上長",
+        comment_text: "お疲れ様です",
+      });
+    });
+  });
+
+  describe("日報詳細取得 - 異常系", () => {
+    it("存在しない日報IDの場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 1, isManager: false },
+      });
+      mockPrismaFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await GET(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("RESOURCE_NOT_FOUND");
+    });
+
+    it("不正なIDフォーマットの場合、422エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 1, isManager: false },
+      });
+
+      const request = createRequest("abc");
+      const response = await GET(request, createContext("abc"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報詳細取得 - 権限チェック", () => {
+    it("他人の日報を閲覧しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 3, name: "別のユーザー", isManager: false },
+      });
+      mockPrismaFindUnique.mockResolvedValue({
+        ...mockReportDetailData,
+        salesPersonId: 1, // 別の人の日報
+      });
+      mockPrismaFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("FORBIDDEN_ACCESS");
+    });
+
+    it("上長は部下の日報を閲覧できること", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 2, name: "テスト上長", isManager: true },
+      });
+      mockPrismaFindUnique.mockResolvedValue(mockReportDetailData);
+      mockPrismaFindFirst.mockResolvedValue({ id: 1 }); // 部下である
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+});
+
+describe("Reports API - PUT /api/v1/reports/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string, body: unknown): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1", {
+        report_date: "2024-01-15",
+        status: "submitted",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報編集 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("日報を編集できること（UT-RPT-009）", async () => {
+      // 既存の日報（下書き）
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "draft",
+      });
+
+      const mockUpdatedReport = {
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "submitted",
+        updatedAt: new Date("2024-01-15T20:00:00Z"),
+      };
+
+      mockPrismaTransaction.mockImplementation(
+        async (callback: (tx: unknown) => Promise<unknown>) => {
+          return callback({
+            visitRecord: {
+              deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+              createMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            dailyReport: {
+              update: vi.fn().mockResolvedValue(mockUpdatedReport),
+            },
+          });
+        }
+      );
+
+      // 顧客が存在することをモック
+      vi.mocked(await import("@/lib/prisma")).prisma.customer.findMany = vi
+        .fn()
+        .mockResolvedValue([{ id: 1 }]);
+
+      const request = createRequest("1", {
+        report_date: "2024-01-15",
+        problem: "更新された課題",
+        plan: "更新された予定",
+        status: "submitted",
+        visits: [{ customer_id: 1, visit_content: "更新された訪問内容" }],
+      });
+
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.message).toBe("日報を更新しました");
+    });
+  });
+
+  describe("日報編集 - 権限チェック", () => {
+    it("確認済の日報は編集できないこと（UT-RPT-010）", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "confirmed", // 確認済
+      });
+
+      // 有効なリクエストボディを提供（バリデーションを通過させる）
+      const request = createRequest("1", {
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [],
+      });
+
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("確認済の日報は編集できません");
+    });
+
+    it("他人の日報を編集しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 2, // 別の人の日報
+        reportDate: new Date("2024-01-15"),
+        status: "draft",
+      });
+
+      // 有効なリクエストボディを提供
+      const request = createRequest("1", {
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [],
+      });
+
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報編集 - 存在チェック", () => {
+    it("存在しない日報を編集しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null);
+
+      // 有効なリクエストボディを提供
+      const request = createRequest("999", {
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [],
+      });
+
+      const response = await PUT(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報編集 - 日付変更時の重複チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("日付変更時に同一日の日報が既に存在する場合、エラーになること", async () => {
+      // 既存の日報（編集対象）
+      mockPrismaFindUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          salesPersonId: 1,
+          reportDate: new Date("2024-01-15"),
+          status: "draft",
+        })
+        // 変更先日付に既存の日報がある
+        .mockResolvedValueOnce({
+          id: 2,
+          salesPersonId: 1,
+          reportDate: new Date("2024-01-16"),
+        });
+
+      const request = createRequest("1", {
+        report_date: "2024-01-16", // 別の日付に変更
+        status: "draft",
+        visits: [],
+      });
+
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("DUPLICATE_ENTRY");
+    });
+  });
+});
+
+describe("Reports API - DELETE /api/v1/reports/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${id}`, {
+      method: "DELETE",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報削除 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("日報を削除できること（UT-RPT-011）", async () => {
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        status: "draft", // 下書きのみ削除可能
+      });
+      mockPrismaDelete.mockResolvedValue({ id: 1 });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.message).toBe("日報を削除しました");
+      expect(body.data.report_id).toBe(1);
+    });
+  });
+
+  describe("日報削除 - 権限チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("下書き以外の日報は削除できないこと", async () => {
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        status: "submitted", // 提出済
+      });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("下書き以外の日報は削除できません");
+    });
+
+    it("他人の日報を削除しようとした場合、403エラーを返すこと", async () => {
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 2, // 別の人の日報
+        status: "draft",
+      });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報削除 - 存在チェック", () => {
+    it("存在しない日報を削除しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await DELETE(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/src/app/api/v1/reports/[id]/status/route.test.ts
+++ b/src/app/api/v1/reports/[id]/status/route.test.ts
@@ -1,0 +1,259 @@
+/**
+ * 日報ステータス更新APIのユニットテスト
+ *
+ * テスト対象:
+ * - PATCH /api/v1/reports/{id}/status - ステータス更新
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PATCH } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaFindUnique = vi.fn();
+const mockPrismaFindFirst = vi.fn();
+const mockPrismaUpdate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: (...args: unknown[]) => mockPrismaFindUnique(...args),
+      update: (...args: unknown[]) => mockPrismaUpdate(...args),
+    },
+    salesPerson: {
+      findFirst: (...args: unknown[]) => mockPrismaFindFirst(...args),
+    },
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Reports API - PATCH /api/v1/reports/{id}/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string, body: unknown): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${id}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  const managerSession = {
+    user: {
+      id: 2,
+      name: "テスト上長",
+      email: "manager@example.com",
+      isManager: true,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1", { status: "submitted" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("ステータス更新 - 正常系", () => {
+    it("本人が下書きから提出済に変更できること", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        status: "draft",
+      });
+      mockPrismaUpdate.mockResolvedValue({
+        id: 1,
+        status: "submitted",
+        updatedAt: new Date("2024-01-15T18:00:00Z"),
+      });
+
+      const request = createRequest("1", { status: "submitted" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe("submitted");
+      expect(body.data.status_label).toBe("提出済");
+      expect(body.message).toBe("ステータスを更新しました");
+    });
+
+    it("上長が日報を確認済にできること（UT-STS-001）", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1, // 部下の日報
+        status: "submitted",
+      });
+      mockPrismaFindFirst.mockResolvedValue({ id: 1, managerId: 2 }); // 部下である
+      mockPrismaUpdate.mockResolvedValue({
+        id: 1,
+        status: "confirmed",
+        updatedAt: new Date("2024-01-15T19:00:00Z"),
+      });
+
+      const request = createRequest("1", { status: "confirmed" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe("confirmed");
+      expect(body.data.status_label).toBe("確認済");
+    });
+  });
+
+  describe("ステータス更新 - 権限チェック", () => {
+    it("一般営業担当者は確認済にできないこと（UT-STS-002）", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        status: "submitted",
+      });
+
+      const request = createRequest("1", { status: "confirmed" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "自分の日報を確認済にすることはできません"
+      );
+    });
+
+    it("上長でも自分の日報は確認済にできないこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 2, // 自分の日報
+        status: "submitted",
+      });
+
+      const request = createRequest("1", { status: "confirmed" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "自分の日報を確認済にすることはできません"
+      );
+    });
+
+    it("他人の日報をdraft/submittedに変更できないこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1, // 部下の日報
+        status: "submitted",
+      });
+      mockPrismaFindFirst.mockResolvedValue({ id: 1, managerId: 2 }); // 部下である
+
+      const request = createRequest("1", { status: "draft" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "他人の日報のステータスを下書きまたは提出済に変更することはできません"
+      );
+    });
+
+    it("アクセス権限のない日報のステータスを更新できないこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: {
+          id: 3,
+          name: "別のユーザー",
+          isManager: false,
+        },
+      });
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1, // 別の人の日報
+        status: "draft",
+      });
+      mockPrismaFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("1", { status: "submitted" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("ステータス更新 - 存在チェック", () => {
+    it("存在しない日報のステータスを更新しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999", { status: "submitted" });
+      const response = await PATCH(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("ステータス更新 - バリデーション", () => {
+    it("無効なステータスを指定した場合、422エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const request = createRequest("1", { status: "invalid" });
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("ステータスが未指定の場合、422エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const request = createRequest("1", {});
+      const response = await PATCH(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/src/app/api/v1/reports/[id]/visits/route.test.ts
+++ b/src/app/api/v1/reports/[id]/visits/route.test.ts
@@ -1,0 +1,438 @@
+/**
+ * 訪問記録API一覧取得・新規作成のユニットテスト
+ *
+ * テスト対象:
+ * - GET /api/v1/reports/{reportId}/visits - 訪問記録一覧取得
+ * - POST /api/v1/reports/{reportId}/visits - 訪問記録新規作成
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaReportFindUnique = vi.fn();
+const mockPrismaVisitFindMany = vi.fn();
+const mockPrismaVisitCreate = vi.fn();
+const mockPrismaCustomerFindUnique = vi.fn();
+const mockPrismaSalesPersonFindFirst = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: (...args: unknown[]) => mockPrismaReportFindUnique(...args),
+    },
+    visitRecord: {
+      findMany: (...args: unknown[]) => mockPrismaVisitFindMany(...args),
+      create: (...args: unknown[]) => mockPrismaVisitCreate(...args),
+    },
+    customer: {
+      findUnique: (...args: unknown[]) => mockPrismaCustomerFindUnique(...args),
+    },
+    salesPerson: {
+      findFirst: (...args: unknown[]) =>
+        mockPrismaSalesPersonFindFirst(...args),
+    },
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Visits API - GET /api/v1/reports/{reportId}/visits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (reportId: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${reportId}/visits`, {
+      method: "GET",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録一覧取得 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("訪問記録一覧を取得できること", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+      });
+      mockPrismaVisitFindMany.mockResolvedValue([
+        {
+          id: 1,
+          customerId: 1,
+          visitTime: new Date("1970-01-01T10:30:00Z"),
+          visitPurpose: "商談",
+          visitContent: "新規提案を行いました",
+          visitResult: "次回アポイント取得",
+          createdAt: new Date("2024-01-15T10:00:00Z"),
+          updatedAt: new Date("2024-01-15T10:00:00Z"),
+          customer: { customerName: "株式会社テスト" },
+        },
+        {
+          id: 2,
+          customerId: 2,
+          visitTime: new Date("1970-01-01T14:00:00Z"),
+          visitPurpose: "フォローアップ",
+          visitContent: "導入後の状況確認",
+          visitResult: null,
+          createdAt: new Date("2024-01-15T14:00:00Z"),
+          updatedAt: new Date("2024-01-15T14:00:00Z"),
+          customer: { customerName: "サンプル商事" },
+        },
+      ]);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(2);
+      expect(body.data.items[0]).toMatchObject({
+        visit_id: 1,
+        customer_id: 1,
+        customer_name: "株式会社テスト",
+        visit_time: "10:30",
+        visit_content: "新規提案を行いました",
+      });
+    });
+
+    it("訪問記録が0件の場合、空配列を返すこと", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+      });
+      mockPrismaVisitFindMany.mockResolvedValue([]);
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(0);
+    });
+  });
+
+  describe("訪問記録一覧取得 - 存在チェック", () => {
+    it("存在しない日報の訪問記録を取得しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaReportFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await GET(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録一覧取得 - 権限チェック", () => {
+    it("他人の日報の訪問記録を取得しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({
+        user: { id: 3, name: "別のユーザー", isManager: false },
+      });
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1, // 別の人の日報
+      });
+      mockPrismaSalesPersonFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("1");
+      const response = await GET(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+  });
+});
+
+describe("Visits API - POST /api/v1/reports/{reportId}/visits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (reportId: string, body: unknown): NextRequest => {
+    return new Request(`http://localhost/api/v1/reports/${reportId}/visits`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録作成 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("訪問記録を作成できること", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "draft",
+      });
+      mockPrismaCustomerFindUnique.mockResolvedValue({
+        id: 1,
+        customerName: "株式会社テスト",
+      });
+      mockPrismaVisitCreate.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        customerId: 1,
+        createdAt: new Date("2024-01-15T10:00:00Z"),
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_time: "10:30",
+        visit_purpose: "商談",
+        visit_content: "新規提案を行いました",
+        visit_result: "次回アポイント取得",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        visit_id: 1,
+        report_id: 1,
+        customer_id: 1,
+        customer_name: "株式会社テスト",
+      });
+      expect(body.message).toBe("訪問記録を作成しました");
+    });
+
+    it("訪問時間がnullでも作成できること", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "draft",
+      });
+      mockPrismaCustomerFindUnique.mockResolvedValue({
+        id: 1,
+        customerName: "株式会社テスト",
+      });
+      mockPrismaVisitCreate.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        customerId: 1,
+        createdAt: new Date("2024-01-15T10:00:00Z"),
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "新規提案を行いました",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe("訪問記録作成 - バリデーションエラー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("顧客IDが未指定の場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", {
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問内容が未入力の場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", {
+        customer_id: 1,
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問内容が1000文字を超える場合、バリデーションエラーになること", async () => {
+      const longContent = "あ".repeat(1001);
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: longContent,
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問時間がHH:MM形式でない場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+        visit_time: "25:00", // 不正な時間
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録作成 - 存在チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("存在しない日報に訪問記録を追加しようとした場合、404エラーを返すこと", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+
+    it("存在しない顧客IDを指定した場合、エラーになること", async () => {
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "draft",
+      });
+      mockPrismaCustomerFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("1", {
+        customer_id: 999,
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("顧客が存在しません");
+    });
+  });
+
+  describe("訪問記録作成 - 権限チェック", () => {
+    it("他人の日報に訪問記録を追加しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 2, // 別の人の日報
+        status: "draft",
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+
+    it("確認済の日報に訪問記録を追加しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaReportFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "confirmed", // 確認済
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await POST(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "確認済の日報には訪問記録を追加できません"
+      );
+    });
+  });
+});

--- a/src/app/api/v1/reports/reports.integration.test.ts
+++ b/src/app/api/v1/reports/reports.integration.test.ts
@@ -1,0 +1,629 @@
+/**
+ * 日報機能 結合テスト
+ *
+ * IT-001: 日報作成から上長確認までの一連のフロー
+ *
+ * テスト仕様書(doc/test_specification.md)に基づく結合テスト
+ *
+ * 本テストは、日報ワークフローの各ステップをシミュレートし、
+ * ステータス遷移と権限チェックが正しく機能することを検証します。
+ *
+ * ワークフローの流れ:
+ * 1. 営業担当者が日報を作成して提出
+ * 2. 上長が日報を確認してコメントを投稿
+ * 3. 上長が日報を確認済ステータスに変更
+ * 4. 営業担当者が上長コメントを確認
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as createComment } from "./[id]/comments/route";
+import {
+  DELETE as deleteReport,
+  GET as getReportDetail,
+  PUT as updateReport,
+} from "./[id]/route";
+import { PATCH as updateStatus } from "./[id]/status/route";
+import { POST as createVisit } from "./[id]/visits/route";
+import { GET as getReportsList } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaFindUnique = vi.fn();
+const mockPrismaFindMany = vi.fn();
+const mockPrismaCount = vi.fn();
+const mockPrismaUpdate = vi.fn();
+const mockPrismaDelete = vi.fn();
+const mockPrismaTransaction = vi.fn();
+const mockSalesPersonFindMany = vi.fn();
+const mockSalesPersonFindFirst = vi.fn();
+const mockCustomerFindMany = vi.fn();
+const mockCustomerFindUnique = vi.fn();
+const mockVisitFindMany = vi.fn();
+const mockVisitCreate = vi.fn();
+const mockCommentFindMany = vi.fn();
+const mockCommentCreate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: (...args: unknown[]) => mockPrismaFindUnique(...args),
+      findMany: (...args: unknown[]) => mockPrismaFindMany(...args),
+      count: (...args: unknown[]) => mockPrismaCount(...args),
+      update: (...args: unknown[]) => mockPrismaUpdate(...args),
+      delete: (...args: unknown[]) => mockPrismaDelete(...args),
+    },
+    salesPerson: {
+      findMany: (...args: unknown[]) => mockSalesPersonFindMany(...args),
+      findFirst: (...args: unknown[]) => mockSalesPersonFindFirst(...args),
+    },
+    customer: {
+      findMany: (...args: unknown[]) => mockCustomerFindMany(...args),
+      findUnique: (...args: unknown[]) => mockCustomerFindUnique(...args),
+    },
+    visitRecord: {
+      findMany: (...args: unknown[]) => mockVisitFindMany(...args),
+      create: (...args: unknown[]) => mockVisitCreate(...args),
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    comment: {
+      findMany: (...args: unknown[]) => mockCommentFindMany(...args),
+      create: (...args: unknown[]) => mockCommentCreate(...args),
+    },
+    $transaction: (...args: unknown[]) => mockPrismaTransaction(...args),
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+// テスト用セッション
+const memberSession = {
+  user: {
+    id: 1,
+    name: "テスト太郎",
+    email: "member@example.com",
+    isManager: false,
+  },
+};
+
+const managerSession = {
+  user: {
+    id: 2,
+    name: "テスト上長",
+    email: "manager@example.com",
+    isManager: true,
+  },
+};
+
+// テスト用日報データ
+const createMockReport = (
+  id: number,
+  salesPersonId: number,
+  status: string,
+  options: {
+    problem?: string;
+    plan?: string;
+    visitCount?: number;
+    commentCount?: number;
+  } = {}
+) => ({
+  id,
+  salesPersonId,
+  reportDate: new Date("2024-01-15"),
+  status,
+  problem: options.problem ?? null,
+  plan: options.plan ?? null,
+  createdAt: new Date("2024-01-15T10:00:00Z"),
+  updatedAt: new Date("2024-01-15T10:00:00Z"),
+  salesPerson: { name: salesPersonId === 1 ? "テスト太郎" : "テスト上長" },
+  visitRecords: Array.from({ length: options.visitCount ?? 0 }, (_, i) => ({
+    id: i + 1,
+    customerId: i + 1,
+    visitTime: new Date("1970-01-01T10:00:00Z"),
+    visitPurpose: "商談",
+    visitContent: `訪問内容${i + 1}`,
+    visitResult: "結果",
+    customer: { customerName: `顧客${i + 1}` },
+  })),
+  comments: Array.from({ length: options.commentCount ?? 0 }, (_, i) => ({
+    id: i + 1,
+    salesPersonId: 2,
+    commentText: `コメント${i + 1}`,
+    createdAt: new Date("2024-01-15T19:00:00Z"),
+    salesPerson: { name: "テスト上長" },
+  })),
+  _count: {
+    visitRecords: options.visitCount ?? 0,
+    comments: options.commentCount ?? 0,
+  },
+});
+
+describe("IT-001: 日報作成から上長確認までの一連のフロー", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // デフォルトのモック設定
+    mockSalesPersonFindMany.mockResolvedValue([{ id: 1 }]); // 部下リスト
+    mockCustomerFindMany.mockResolvedValue([{ id: 1 }, { id: 2 }]); // 顧客リスト
+    mockCustomerFindUnique.mockResolvedValue({
+      id: 1,
+      customerName: "株式会社テスト",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (
+    url: string,
+    method: string,
+    body?: unknown
+  ): NextRequest => {
+    const options: RequestInit = { method };
+    if (body) {
+      options.headers = { "Content-Type": "application/json" };
+      options.body = JSON.stringify(body);
+    }
+    return new Request(url, options) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const createEmptyContext = () => ({
+    params: Promise.resolve({}),
+  });
+
+  describe("ワークフロー全体のステータス遷移検証", () => {
+    it("日報のステータスが 下書き -> 提出済 -> 確認済 と正しく遷移すること", async () => {
+      // ================================================
+      // Step 1: 営業担当者が下書きから提出済に変更
+      // ================================================
+      mockAuth.mockResolvedValue(memberSession);
+
+      // 下書き状態の日報
+      const draftReport = createMockReport(1, 1, "draft", { visitCount: 2 });
+      mockPrismaFindUnique.mockResolvedValueOnce(draftReport);
+      mockPrismaUpdate.mockResolvedValueOnce({
+        ...draftReport,
+        status: "submitted",
+        updatedAt: new Date(),
+      });
+
+      // 下書きから提出済に変更
+      const submitRequest = createRequest(
+        "http://localhost/api/v1/reports/1/status",
+        "PATCH",
+        { status: "submitted" }
+      );
+
+      const submitResponse = await updateStatus(
+        submitRequest,
+        createContext("1")
+      );
+      const submitBody = await submitResponse.json();
+
+      expect(submitResponse.status).toBe(200);
+      expect(submitBody.success).toBe(true);
+      expect(submitBody.data.status).toBe("submitted");
+      expect(submitBody.data.status_label).toBe("提出済");
+
+      // ================================================
+      // Step 2: 上長が確認済に変更
+      // ================================================
+      mockAuth.mockResolvedValue(managerSession);
+
+      // 提出済状態の日報
+      const submittedReport = createMockReport(1, 1, "submitted", {
+        visitCount: 2,
+      });
+      mockPrismaFindUnique.mockResolvedValueOnce(submittedReport);
+      mockSalesPersonFindFirst.mockResolvedValueOnce({ id: 1, managerId: 2 }); // 部下である
+      mockPrismaUpdate.mockResolvedValueOnce({
+        ...submittedReport,
+        status: "confirmed",
+        updatedAt: new Date(),
+      });
+
+      const confirmRequest = createRequest(
+        "http://localhost/api/v1/reports/1/status",
+        "PATCH",
+        { status: "confirmed" }
+      );
+
+      const confirmResponse = await updateStatus(
+        confirmRequest,
+        createContext("1")
+      );
+      const confirmBody = await confirmResponse.json();
+
+      expect(confirmResponse.status).toBe(200);
+      expect(confirmBody.success).toBe(true);
+      expect(confirmBody.data.status).toBe("confirmed");
+      expect(confirmBody.data.status_label).toBe("確認済");
+    });
+
+    it("上長がコメントを投稿して日報を確認済にするフローが正常に動作すること", async () => {
+      // ================================================
+      // Step 1: 上長がコメントを投稿
+      // ================================================
+      mockAuth.mockResolvedValue(managerSession);
+
+      const submittedReport = createMockReport(1, 1, "submitted", {
+        visitCount: 2,
+      });
+      mockPrismaFindUnique.mockResolvedValueOnce({ salesPersonId: 1 }); // 日報の存在確認
+      mockSalesPersonFindFirst.mockResolvedValueOnce({ id: 1, managerId: 2 }); // 部下である
+      mockCommentCreate.mockResolvedValueOnce({
+        id: 1,
+        reportId: 1,
+        salesPersonId: 2,
+        commentText: "お疲れ様です。良い成果ですね。",
+        createdAt: new Date(),
+      });
+
+      const commentRequest = createRequest(
+        "http://localhost/api/v1/reports/1/comments",
+        "POST",
+        { comment_text: "お疲れ様です。良い成果ですね。" }
+      );
+
+      const commentResponse = await createComment(
+        commentRequest,
+        createContext("1")
+      );
+      const commentBody = await commentResponse.json();
+
+      expect(commentResponse.status).toBe(201);
+      expect(commentBody.success).toBe(true);
+      expect(commentBody.data.comment_id).toBe(1);
+      expect(commentBody.message).toBe("コメントを投稿しました");
+
+      // ================================================
+      // Step 2: 上長が確認済に変更
+      // ================================================
+      mockPrismaFindUnique.mockResolvedValueOnce(submittedReport);
+      mockSalesPersonFindFirst.mockResolvedValueOnce({ id: 1, managerId: 2 }); // 部下である
+      mockPrismaUpdate.mockResolvedValueOnce({
+        ...submittedReport,
+        status: "confirmed",
+        updatedAt: new Date(),
+      });
+
+      const statusRequest = createRequest(
+        "http://localhost/api/v1/reports/1/status",
+        "PATCH",
+        { status: "confirmed" }
+      );
+
+      const statusResponse = await updateStatus(
+        statusRequest,
+        createContext("1")
+      );
+      const statusBody = await statusResponse.json();
+
+      expect(statusResponse.status).toBe(200);
+      expect(statusBody.success).toBe(true);
+      expect(statusBody.data.status).toBe("confirmed");
+
+      // ================================================
+      // Step 3: 営業担当者がコメントを確認
+      // ================================================
+      mockAuth.mockResolvedValue(memberSession);
+
+      const confirmedReport = createMockReport(1, 1, "confirmed", {
+        visitCount: 2,
+        commentCount: 1,
+        problem: "テスト課題",
+        plan: "テスト予定",
+      });
+      mockPrismaFindUnique.mockResolvedValueOnce(confirmedReport);
+
+      const detailRequest = createRequest(
+        "http://localhost/api/v1/reports/1",
+        "GET"
+      );
+
+      const detailResponse = await getReportDetail(
+        detailRequest,
+        createContext("1")
+      );
+      const detailBody = await detailResponse.json();
+
+      expect(detailResponse.status).toBe(200);
+      expect(detailBody.success).toBe(true);
+      expect(detailBody.data.status).toBe("confirmed");
+      expect(detailBody.data.status_label).toBe("確認済");
+      expect(detailBody.data.comments).toHaveLength(1);
+    });
+  });
+
+  describe("権限チェックの検証", () => {
+    it("一般営業担当者は自分の日報を確認済にできないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const submittedReport = createMockReport(1, 1, "submitted");
+      mockPrismaFindUnique.mockResolvedValue(submittedReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1/status",
+        "PATCH",
+        { status: "confirmed" }
+      );
+
+      const response = await updateStatus(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "自分の日報を確認済にすることはできません"
+      );
+    });
+
+    it("上長は自分の日報を確認済にできないこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+
+      // 上長自身の日報
+      const ownReport = createMockReport(1, 2, "submitted"); // salesPersonId=2 (上長)
+      mockPrismaFindUnique.mockResolvedValue(ownReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1/status",
+        "PATCH",
+        { status: "confirmed" }
+      );
+
+      const response = await updateStatus(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "自分の日報を確認済にすることはできません"
+      );
+    });
+
+    it("一般営業担当者はコメントを投稿できないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1/comments",
+        "POST",
+        { comment_text: "テストコメント" }
+      );
+
+      const response = await createComment(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("上長のみ");
+    });
+
+    it("確認済の日報は編集できないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const confirmedReport = createMockReport(1, 1, "confirmed");
+      mockPrismaFindUnique.mockResolvedValue(confirmedReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1",
+        "PUT",
+        {
+          report_date: "2024-01-15",
+          status: "draft",
+          visits: [],
+        }
+      );
+
+      const response = await updateReport(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("確認済の日報は編集できません");
+    });
+
+    it("上長は部下以外の日報にアクセスできないこと", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+
+      // 部下ではない人の日報
+      const otherReport = createMockReport(1, 3, "submitted"); // salesPersonId=3 (別の人)
+      mockPrismaFindUnique.mockResolvedValue(otherReport);
+      mockSalesPersonFindFirst.mockResolvedValue(null); // 部下ではない
+
+      const request = createRequest("http://localhost/api/v1/reports/1", "GET");
+
+      const response = await getReportDetail(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("閲覧する権限がありません");
+    });
+  });
+
+  describe("下書き・削除の検証", () => {
+    it("下書き状態の日報は削除できること", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const draftReport = createMockReport(1, 1, "draft");
+      mockPrismaFindUnique.mockResolvedValue(draftReport);
+      mockPrismaDelete.mockResolvedValue(draftReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1",
+        "DELETE"
+      );
+
+      const response = await deleteReport(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.message).toBe("日報を削除しました");
+    });
+
+    it("提出済の日報は削除できないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const submittedReport = createMockReport(1, 1, "submitted");
+      mockPrismaFindUnique.mockResolvedValue(submittedReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1",
+        "DELETE"
+      );
+
+      const response = await deleteReport(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("下書き以外の日報は削除できません");
+    });
+
+    it("確認済の日報は削除できないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const confirmedReport = createMockReport(1, 1, "confirmed");
+      mockPrismaFindUnique.mockResolvedValue(confirmedReport);
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1",
+        "DELETE"
+      );
+
+      const response = await deleteReport(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("下書き以外の日報は削除できません");
+    });
+  });
+
+  describe("訪問記録の操作検証", () => {
+    it("確認済の日報には訪問記録を追加できないこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      // 確認済の日報
+      mockPrismaFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "confirmed",
+      });
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1/visits",
+        "POST",
+        {
+          customer_id: 1,
+          visit_content: "追加しようとした訪問記録",
+        }
+      );
+
+      const response = await createVisit(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "確認済の日報には訪問記録を追加できません"
+      );
+    });
+
+    it("下書き状態の日報には訪問記録を追加できること", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      // 下書き状態の日報
+      mockPrismaFindUnique.mockResolvedValue({
+        salesPersonId: 1,
+        status: "draft",
+      });
+      mockCustomerFindUnique.mockResolvedValue({
+        id: 1,
+        customerName: "株式会社テスト",
+      });
+      mockVisitCreate.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        customerId: 1,
+        createdAt: new Date(),
+      });
+
+      const request = createRequest(
+        "http://localhost/api/v1/reports/1/visits",
+        "POST",
+        {
+          customer_id: 1,
+          visit_time: "10:00",
+          visit_content: "新しい訪問記録",
+        }
+      );
+
+      const response = await createVisit(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.message).toBe("訪問記録を作成しました");
+    });
+  });
+
+  describe("日報一覧の権限フィルタリング検証", () => {
+    it("一般営業担当者は自分の日報のみ取得できること", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+
+      const myReports = [
+        createMockReport(1, 1, "submitted", { visitCount: 2 }),
+        createMockReport(2, 1, "draft", { visitCount: 0 }),
+      ];
+      mockPrismaCount.mockResolvedValue(2);
+      mockPrismaFindMany.mockResolvedValue(myReports);
+
+      const request = createRequest("http://localhost/api/v1/reports", "GET");
+
+      const response = await getReportsList(request, createEmptyContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(2);
+      // 全て自分の日報であることを確認
+      body.data.items.forEach((item: { sales_person_id: number }) => {
+        expect(item.sales_person_id).toBe(1);
+      });
+    });
+
+    it("上長は自分と部下の日報を取得できること", async () => {
+      mockAuth.mockResolvedValue(managerSession);
+
+      // 上長の部下
+      mockSalesPersonFindMany.mockResolvedValue([{ id: 1 }]);
+
+      const reports = [
+        createMockReport(1, 1, "submitted", { visitCount: 2 }), // 部下の日報
+        createMockReport(2, 2, "draft", { visitCount: 1 }), // 自分の日報
+      ];
+      mockPrismaCount.mockResolvedValue(2);
+      mockPrismaFindMany.mockResolvedValue(reports);
+
+      const request = createRequest("http://localhost/api/v1/reports", "GET");
+
+      const response = await getReportsList(request, createEmptyContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(2);
+    });
+  });
+});

--- a/src/app/api/v1/reports/route.test.ts
+++ b/src/app/api/v1/reports/route.test.ts
@@ -1,0 +1,658 @@
+/**
+ * 日報API一覧取得・新規作成のユニットテスト
+ *
+ * テスト対象:
+ * - GET /api/v1/reports - 日報一覧取得
+ * - POST /api/v1/reports - 日報新規作成
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaFindMany = vi.fn();
+const mockPrismaFindUnique = vi.fn();
+const mockPrismaCount = vi.fn();
+const mockPrismaCreate = vi.fn();
+const mockPrismaTransaction = vi.fn();
+const mockSalesPersonFindMany = vi.fn();
+const mockCustomerFindMany = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dailyReport: {
+      findMany: (...args: unknown[]) => mockPrismaFindMany(...args),
+      findUnique: (...args: unknown[]) => mockPrismaFindUnique(...args),
+      count: (...args: unknown[]) => mockPrismaCount(...args),
+      create: (...args: unknown[]) => mockPrismaCreate(...args),
+    },
+    salesPerson: {
+      findMany: (...args: unknown[]) => mockSalesPersonFindMany(...args),
+    },
+    customer: {
+      findMany: (...args: unknown[]) => mockCustomerFindMany(...args),
+    },
+    visitRecord: {
+      createMany: vi.fn(),
+    },
+    $transaction: (...args: unknown[]) => mockPrismaTransaction(...args),
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Reports API - GET /api/v1/reports", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (params: Record<string, string> = {}): NextRequest => {
+    const searchParams = new URLSearchParams(params);
+    const url = `http://localhost/api/v1/reports?${searchParams.toString()}`;
+    return new Request(url, { method: "GET" }) as unknown as NextRequest;
+  };
+
+  const createContext = () => ({
+    params: Promise.resolve({}),
+  });
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest();
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_UNAUTHORIZED");
+    });
+
+    it("セッションにユーザー情報がない場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue({ user: null });
+
+      const request = createRequest();
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("一覧取得 - 一般営業担当者", () => {
+    const memberSession = {
+      user: {
+        id: 1,
+        name: "テスト太郎",
+        email: "member@example.com",
+        isManager: false,
+      },
+    };
+
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("自分の日報一覧を取得できること", async () => {
+      const mockReports = [
+        {
+          id: 1,
+          reportDate: new Date("2024-01-15"),
+          salesPersonId: 1,
+          status: "submitted",
+          createdAt: new Date("2024-01-15T10:00:00Z"),
+          updatedAt: new Date("2024-01-15T18:00:00Z"),
+          salesPerson: { name: "テスト太郎" },
+          _count: { visitRecords: 3, comments: 1 },
+        },
+        {
+          id: 2,
+          reportDate: new Date("2024-01-14"),
+          salesPersonId: 1,
+          status: "draft",
+          createdAt: new Date("2024-01-14T10:00:00Z"),
+          updatedAt: new Date("2024-01-14T12:00:00Z"),
+          salesPerson: { name: "テスト太郎" },
+          _count: { visitRecords: 0, comments: 0 },
+        },
+      ];
+
+      mockPrismaCount.mockResolvedValue(2);
+      mockPrismaFindMany.mockResolvedValue(mockReports);
+
+      const request = createRequest();
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(2);
+      expect(body.data.items[0]).toMatchObject({
+        report_id: 1,
+        report_date: "2024-01-15",
+        sales_person_id: 1,
+        sales_person_name: "テスト太郎",
+        status: "submitted",
+        status_label: "提出済",
+        visit_count: 3,
+        comment_count: 1,
+      });
+      expect(body.data.pagination.total).toBe(2);
+    });
+
+    it("日報が0件の場合、空配列を返すこと", async () => {
+      mockPrismaCount.mockResolvedValue(0);
+      mockPrismaFindMany.mockResolvedValue([]);
+
+      const request = createRequest();
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(0);
+      expect(body.data.pagination.total).toBe(0);
+    });
+  });
+
+  describe("検索条件フィルタリング", () => {
+    const memberSession = {
+      user: {
+        id: 1,
+        name: "テスト太郎",
+        email: "member@example.com",
+        isManager: false,
+      },
+    };
+
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaCount.mockResolvedValue(0);
+      mockPrismaFindMany.mockResolvedValue([]);
+    });
+
+    it("期間指定で検索できること（UT-RPT-002）", async () => {
+      const request = createRequest({
+        date_from: "2024-01-01",
+        date_to: "2024-01-31",
+      });
+
+      await GET(request, createContext());
+
+      expect(mockPrismaCount).toHaveBeenCalled();
+      const countCall = mockPrismaCount.mock.calls[0]![0];
+      expect(countCall.where.reportDate).toMatchObject({
+        gte: new Date("2024-01-01"),
+        lte: new Date("2024-01-31"),
+      });
+    });
+
+    it("ステータス指定で検索できること（UT-RPT-003）", async () => {
+      const request = createRequest({ status: "submitted" });
+
+      await GET(request, createContext());
+
+      expect(mockPrismaCount).toHaveBeenCalled();
+      const countCall = mockPrismaCount.mock.calls[0]![0];
+      expect(countCall.where.status).toBe("submitted");
+    });
+
+    it("ページネーションが正しく動作すること", async () => {
+      mockPrismaCount.mockResolvedValue(50);
+
+      const request = createRequest({ page: "2", per_page: "10" });
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      expect(body.data.pagination).toMatchObject({
+        current_page: 2,
+        per_page: 10,
+        total: 50,
+        last_page: 5,
+      });
+    });
+
+    it("ソート条件が正しく適用されること", async () => {
+      const request = createRequest({ sort: "created_at", order: "asc" });
+
+      await GET(request, createContext());
+
+      const findManyCall = mockPrismaFindMany.mock.calls[0]![0];
+      expect(findManyCall.orderBy.createdAt).toBe("asc");
+    });
+  });
+
+  describe("一覧取得 - 上長", () => {
+    const managerSession = {
+      user: {
+        id: 2,
+        name: "テスト上長",
+        email: "manager@example.com",
+        isManager: true,
+      },
+    };
+
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(managerSession);
+      // 部下IDを取得するためのfindManyモック
+      mockSalesPersonFindMany.mockResolvedValue([{ id: 1 }]);
+      mockPrismaCount.mockResolvedValue(0);
+      mockPrismaFindMany.mockResolvedValue([]);
+    });
+
+    it("自分と部下の日報を取得できること", async () => {
+      const request = createRequest();
+
+      const response = await GET(request, createContext());
+      const body = await response.json();
+
+      // レスポンスが成功することを確認
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+});
+
+describe("Reports API - POST /api/v1/reports", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (body: unknown): NextRequest => {
+    return new Request("http://localhost/api/v1/reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = () => ({
+    params: Promise.resolve({}),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+      });
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報作成 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null); // 同一日の日報なし
+    });
+
+    it("日報を新規作成できること（UT-RPT-004）", async () => {
+      const mockCreatedReport = {
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "submitted",
+        createdAt: new Date("2024-01-15T10:00:00Z"),
+        updatedAt: new Date("2024-01-15T10:00:00Z"),
+      };
+
+      // 顧客が存在することをモック
+      mockCustomerFindMany.mockResolvedValue([{ id: 1 }]);
+
+      mockPrismaTransaction.mockImplementation(
+        async (callback: (tx: unknown) => Promise<unknown>) => {
+          return callback({
+            dailyReport: {
+              create: vi.fn().mockResolvedValue(mockCreatedReport),
+            },
+            visitRecord: {
+              createMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+          });
+        }
+      );
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        problem: "課題テスト",
+        plan: "予定テスト",
+        status: "submitted",
+        visits: [
+          {
+            customer_id: 1,
+            visit_time: "10:30",
+            visit_content: "商談を行いました",
+          },
+        ],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data.report_id).toBe(1);
+      expect(body.data.status).toBe("submitted");
+      expect(body.message).toBe("日報を作成しました");
+    });
+
+    it("日報を下書き保存できること（UT-RPT-005）", async () => {
+      const mockCreatedReport = {
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "draft",
+        createdAt: new Date("2024-01-15T10:00:00Z"),
+        updatedAt: new Date("2024-01-15T10:00:00Z"),
+      };
+
+      mockPrismaTransaction.mockImplementation(
+        async (callback: (tx: unknown) => Promise<unknown>) => {
+          return callback({
+            dailyReport: {
+              create: vi.fn().mockResolvedValue(mockCreatedReport),
+            },
+            visitRecord: {
+              createMany: vi.fn(),
+            },
+          });
+        }
+      );
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe("draft");
+    });
+  });
+
+  describe("日報作成 - バリデーションエラー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("報告日が未入力の場合、バリデーションエラーになること", async () => {
+      const request = createRequest({
+        status: "draft",
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("報告日が未来日の場合、バリデーションエラーになること", async () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 10);
+      const futureDateStr = futureDate.toISOString().split("T")[0];
+
+      const request = createRequest({
+        report_date: futureDateStr,
+        status: "draft",
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("未来日"),
+          }),
+        ])
+      );
+    });
+
+    it("提出時に訪問記録がない場合、バリデーションエラーになること（UT-RPT-006）", async () => {
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "submitted",
+        visits: [],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("訪問記録を1件以上"),
+          }),
+        ])
+      );
+    });
+
+    it("課題・相談が2000文字を超える場合、バリデーションエラーになること", async () => {
+      const longProblem = "あ".repeat(2001);
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        problem: longProblem,
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("明日の予定が2000文字を超える場合、バリデーションエラーになること", async () => {
+      const longPlan = "あ".repeat(2001);
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        plan: longPlan,
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報作成 - 重複チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("同一日の日報が既に存在する場合、エラーになること", async () => {
+      mockPrismaFindUnique.mockResolvedValue({
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+      });
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("DUPLICATE_ENTRY");
+    });
+  });
+
+  describe("日報作成 - 訪問記録", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null);
+    });
+
+    it("訪問記録を複数追加できること（UT-RPT-007）", async () => {
+      const mockCreatedReport = {
+        id: 1,
+        salesPersonId: 1,
+        reportDate: new Date("2024-01-15"),
+        status: "submitted",
+        createdAt: new Date("2024-01-15T10:00:00Z"),
+        updatedAt: new Date("2024-01-15T10:00:00Z"),
+      };
+
+      // 顧客が存在することをモック
+      mockCustomerFindMany.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+      let visitRecordsData: unknown[] = [];
+      mockPrismaTransaction.mockImplementation(
+        async (callback: (tx: unknown) => Promise<unknown>) => {
+          return callback({
+            dailyReport: {
+              create: vi.fn().mockResolvedValue(mockCreatedReport),
+            },
+            visitRecord: {
+              createMany: vi.fn().mockImplementation(({ data }) => {
+                visitRecordsData = data;
+                return { count: data.length };
+              }),
+            },
+          });
+        }
+      );
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "submitted",
+        visits: [
+          { customer_id: 1, visit_content: "訪問1" },
+          { customer_id: 2, visit_content: "訪問2" },
+          { customer_id: 3, visit_content: "訪問3" },
+        ],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(visitRecordsData).toHaveLength(3);
+    });
+
+    it("訪問記録の訪問内容が必須であること", async () => {
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [
+          { customer_id: 1 }, // visit_contentがない
+        ],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問記録の訪問内容が1000文字を超える場合、バリデーションエラーになること", async () => {
+      const longContent = "あ".repeat(1001);
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [{ customer_id: 1, visit_content: longContent }],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問時間がHH:MM形式でない場合、バリデーションエラーになること", async () => {
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "draft",
+        visits: [
+          { customer_id: 1, visit_content: "テスト", visit_time: "25:00" },
+        ],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("日報作成 - 顧客存在チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaFindUnique.mockResolvedValue(null);
+    });
+
+    it("存在しない顧客IDを指定した場合、エラーになること", async () => {
+      // 顧客が存在しないことをモック
+      mockCustomerFindMany.mockResolvedValue([]);
+
+      const request = createRequest({
+        report_date: "2024-01-15",
+        status: "submitted",
+        visits: [{ customer_id: 999, visit_content: "存在しない顧客" }],
+      });
+
+      const response = await POST(request, createContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("顧客が存在しません");
+    });
+  });
+});

--- a/src/app/api/v1/visits/[id]/route.test.ts
+++ b/src/app/api/v1/visits/[id]/route.test.ts
@@ -1,0 +1,393 @@
+/**
+ * 訪問記録API更新・削除のユニットテスト
+ *
+ * テスト対象:
+ * - PUT /api/v1/visits/{id} - 訪問記録更新
+ * - DELETE /api/v1/visits/{id} - 訪問記録削除
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, PUT } from "./route";
+
+import type { NextRequest } from "next/server";
+
+// Prismaモック
+const mockPrismaVisitFindUnique = vi.fn();
+const mockPrismaVisitUpdate = vi.fn();
+const mockPrismaVisitDelete = vi.fn();
+const mockPrismaCustomerFindUnique = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    visitRecord: {
+      findUnique: (...args: unknown[]) => mockPrismaVisitFindUnique(...args),
+      update: (...args: unknown[]) => mockPrismaVisitUpdate(...args),
+      delete: (...args: unknown[]) => mockPrismaVisitDelete(...args),
+    },
+    customer: {
+      findUnique: (...args: unknown[]) => mockPrismaCustomerFindUnique(...args),
+    },
+  },
+}));
+
+// 認証モック
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+describe("Visits API - PUT /api/v1/visits/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string, body: unknown): NextRequest => {
+    return new Request(`http://localhost/api/v1/visits/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "更新テスト",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録更新 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("訪問記録を更新できること", async () => {
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        customerId: 1,
+        dailyReport: {
+          salesPersonId: 1,
+          status: "draft",
+        },
+      });
+      mockPrismaCustomerFindUnique.mockResolvedValue({
+        id: 2,
+        customerName: "新しい顧客",
+      });
+      mockPrismaVisitUpdate.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        customerId: 2,
+        updatedAt: new Date("2024-01-15T18:00:00Z"),
+      });
+
+      const request = createRequest("1", {
+        customer_id: 2,
+        visit_time: "14:00",
+        visit_purpose: "フォローアップ",
+        visit_content: "更新されたテスト訪問",
+        visit_result: "契約獲得",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        visit_id: 1,
+        report_id: 1,
+        customer_id: 2,
+        customer_name: "新しい顧客",
+      });
+      expect(body.message).toBe("訪問記録を更新しました");
+    });
+  });
+
+  describe("訪問記録更新 - バリデーションエラー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("顧客IDが未指定の場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", {
+        visit_content: "テスト訪問",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問内容が未入力の場合、バリデーションエラーになること", async () => {
+      const request = createRequest("1", {
+        customer_id: 1,
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+
+    it("訪問内容が1000文字を超える場合、バリデーションエラーになること", async () => {
+      const longContent = "あ".repeat(1001);
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: longContent,
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録更新 - 存在チェック", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("存在しない訪問記録を更新しようとした場合、404エラーを返すこと", async () => {
+      mockPrismaVisitFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await PUT(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+
+    it("存在しない顧客IDを指定した場合、エラーになること", async () => {
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 1,
+          status: "draft",
+        },
+      });
+      mockPrismaCustomerFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("1", {
+        customer_id: 999,
+        visit_content: "テスト訪問",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain("顧客が存在しません");
+    });
+  });
+
+  describe("訪問記録更新 - 権限チェック", () => {
+    it("他人の日報の訪問記録を更新しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 2, // 別の人の日報
+          status: "draft",
+        },
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+
+    it("確認済の日報の訪問記録を更新しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 1,
+          status: "confirmed", // 確認済
+        },
+      });
+
+      const request = createRequest("1", {
+        customer_id: 1,
+        visit_content: "テスト訪問",
+      });
+      const response = await PUT(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "確認済の日報の訪問記録は編集できません"
+      );
+    });
+  });
+});
+
+describe("Visits API - DELETE /api/v1/visits/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createRequest = (id: string): NextRequest => {
+    return new Request(`http://localhost/api/v1/visits/${id}`, {
+      method: "DELETE",
+    }) as unknown as NextRequest;
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  const memberSession = {
+    user: {
+      id: 1,
+      name: "テスト太郎",
+      email: "member@example.com",
+      isManager: false,
+    },
+  };
+
+  describe("認証チェック", () => {
+    it("未認証の場合、401エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録削除 - 正常系", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(memberSession);
+    });
+
+    it("訪問記録を削除できること（UT-RPT-008）", async () => {
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 1,
+          status: "draft",
+        },
+      });
+      mockPrismaVisitDelete.mockResolvedValue({ id: 1 });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.visit_id).toBe(1);
+      expect(body.message).toBe("訪問記録を削除しました");
+    });
+  });
+
+  describe("訪問記録削除 - 存在チェック", () => {
+    it("存在しない訪問記録を削除しようとした場合、404エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaVisitFindUnique.mockResolvedValue(null);
+
+      const request = createRequest("999");
+      const response = await DELETE(request, createContext("999"));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("訪問記録削除 - 権限チェック", () => {
+    it("他人の日報の訪問記録を削除しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 2, // 別の人の日報
+          status: "draft",
+        },
+      });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+    });
+
+    it("確認済の日報の訪問記録を削除しようとした場合、403エラーを返すこと", async () => {
+      mockAuth.mockResolvedValue(memberSession);
+      mockPrismaVisitFindUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salesPersonId: 1,
+          status: "confirmed", // 確認済
+        },
+      });
+
+      const request = createRequest("1");
+      const response = await DELETE(request, createContext("1"));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.message).toContain(
+        "確認済の日報の訪問記録は削除できません"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 日報機能（Reports）の単体テスト・結合テストを実装
- 訪問記録（Visits）APIのテストを追加
- コメント（Comments）APIのテストを追加
- 全テスト980件がパス

## テスト対象API

### 日報API
- `GET /api/v1/reports` - 日報一覧取得
- `POST /api/v1/reports` - 日報作成
- `GET /api/v1/reports/{id}` - 日報詳細取得
- `PUT /api/v1/reports/{id}` - 日報更新
- `DELETE /api/v1/reports/{id}` - 日報削除
- `PATCH /api/v1/reports/{id}/status` - ステータス更新

### 訪問記録API
- `GET /api/v1/reports/{id}/visits` - 訪問記録一覧取得
- `POST /api/v1/reports/{id}/visits` - 訪問記録作成
- `PUT /api/v1/visits/{id}` - 訪問記録更新
- `DELETE /api/v1/visits/{id}` - 訪問記録削除

### コメントAPI
- `GET /api/v1/reports/{id}/comments` - コメント一覧取得
- `POST /api/v1/reports/{id}/comments` - コメント作成
- `DELETE /api/v1/comments/{id}` - コメント削除

## テスト仕様対応
- UT-RPT-001〜012: 日報機能単体テスト
- UT-VST-001〜004: 訪問記録単体テスト
- UT-CMT-001〜003: コメント単体テスト
- UT-STS-001〜002: ステータス更新単体テスト
- IT-001: 日報機能統合テスト

## Test plan
- [x] npm run test:run でテストが全てパス (980 tests passed)
- [x] npm run lint でESLintエラーなし
- [x] npm run type-check で型エラーなし

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)