### PR TITLE
test: Issue #20 コメント・ステータス機能のコンポーネントテスト実装

### DIFF
--- a/src/features/reports/components/ReportStatusBadge.test.tsx
+++ b/src/features/reports/components/ReportStatusBadge.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * ReportStatusBadgeコンポーネントのユニットテスト
+ *
+ * テスト対象:
+ * - ステータスに応じたラベル表示
+ * - ステータスに応じたスタイル適用
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { render, screen, mockMemberUser } from "@/test/test-utils";
+
+import { ReportStatusBadge } from "./ReportStatusBadge";
+
+describe("ReportStatusBadge", () => {
+  describe("ステータスラベルの表示", () => {
+    it("下書き（draft）ステータスが正しく表示されること", () => {
+      render(<ReportStatusBadge status="draft" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("下書き")).toBeInTheDocument();
+    });
+
+    it("提出済（submitted）ステータスが正しく表示されること", () => {
+      render(<ReportStatusBadge status="submitted" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("提出済")).toBeInTheDocument();
+    });
+
+    it("確認済（confirmed）ステータスが正しく表示されること", () => {
+      render(<ReportStatusBadge status="confirmed" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("確認済")).toBeInTheDocument();
+    });
+  });
+
+  describe("スタイル適用", () => {
+    it("下書き（draft）ステータスにグレーのスタイルが適用されること", () => {
+      render(<ReportStatusBadge status="draft" />, {
+        user: mockMemberUser,
+      });
+
+      const badge = screen.getByText("下書き");
+      expect(badge).toHaveClass("bg-gray-100");
+      expect(badge).toHaveClass("text-gray-800");
+    });
+
+    it("提出済（submitted）ステータスに青のスタイルが適用されること", () => {
+      render(<ReportStatusBadge status="submitted" />, {
+        user: mockMemberUser,
+      });
+
+      const badge = screen.getByText("提出済");
+      expect(badge).toHaveClass("bg-blue-100");
+      expect(badge).toHaveClass("text-blue-800");
+    });
+
+    it("確認済（confirmed）ステータスに緑のスタイルが適用されること", () => {
+      render(<ReportStatusBadge status="confirmed" />, {
+        user: mockMemberUser,
+      });
+
+      const badge = screen.getByText("確認済");
+      expect(badge).toHaveClass("bg-green-100");
+      expect(badge).toHaveClass("text-green-800");
+    });
+  });
+
+  describe("カスタムクラス", () => {
+    it("classNameプロパティで追加のクラスを適用できること", () => {
+      render(<ReportStatusBadge status="draft" className="custom-class" />, {
+        user: mockMemberUser,
+      });
+
+      const badge = screen.getByText("下書き");
+      expect(badge).toHaveClass("custom-class");
+    });
+
+    it("classNameが未指定でもエラーにならないこと", () => {
+      render(<ReportStatusBadge status="submitted" />, {
+        user: mockMemberUser,
+      });
+
+      expect(screen.getByText("提出済")).toBeInTheDocument();
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("バッジがインラインで表示されること", () => {
+      render(<ReportStatusBadge status="confirmed" />, {
+        user: mockMemberUser,
+      });
+
+      // Badgeコンポーネントはinline-flexなのでvisibleであることを確認
+      const badge = screen.getByText("確認済");
+      expect(badge).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ReportStatusBadgeコンポーネントのユニットテストを追加
- 既存テストの権限チェックカバレッジを確認

## テスト対象

### 新規追加テスト
- `ReportStatusBadge.test.tsx` (9テスト)
  - ステータスラベル表示（下書き/提出済/確認済）
  - スタイル適用（グレー/青/緑）
  - カスタムクラス適用
  - アクセシビリティ

### 既存テストで対応済み
以下のテストはすでに実装済みでした:

| テスト仕様 | テストファイル | カバー内容 |
|-----------|--------------|----------|
| UT-CMT-001 | CommentForm.test.tsx | 上長がコメント投稿可能 |
| UT-CMT-002 | ReportDetail.test.tsx:331-341 | 一般営業はコメントフォーム非表示 |
| UT-CMT-003 | CommentList.test.tsx:100-159 | 自分のコメントのみ削除可能 |
| UT-STS-001 | ReportDetail.test.tsx:253-266 | 上長が確認済ボタン表示 |
| UT-STS-002 | ReportDetail.test.tsx:303-316 | 一般営業は確認済ボタン非表示 |

## Test plan
- [x] npm run test:run でテストがパス (989 tests passed)
- [x] npm run lint でESLintエラーなし
- [x] npm run type-check で型エラーなし

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)