### PR TITLE
feat: Issue #53 ログイン後のデフォルト遷移先をダッシュボードに変更

### DIFF
--- a/src/components/auth/login-form.test.tsx
+++ b/src/components/auth/login-form.test.tsx
@@ -207,7 +207,7 @@ describe("LoginForm", () => {
         expect(mockLogin).toHaveBeenCalledWith(
           "test@example.com",
           "password123",
-          "/"
+          "/dashboard"
         );
       });
     });
@@ -230,7 +230,7 @@ describe("LoginForm", () => {
 
       // Assert
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith("/");
+        expect(mockPush).toHaveBeenCalledWith("/dashboard");
         expect(mockRefresh).toHaveBeenCalled();
       });
     });
@@ -494,7 +494,7 @@ describe("LoginForm", () => {
         expect(mockLogin).toHaveBeenCalledWith(
           "test@example.com",
           "password123",
-          "/"
+          "/dashboard"
         );
       });
     });

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -35,7 +35,7 @@ type LoginFormValues = z.infer<typeof loginSchema>;
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 


### PR DESCRIPTION
## Summary
- ログイン成功後、callbackUrlが指定されていない場合はダッシュボード（`/dashboard`）に遷移するように変更
- 関連するテストケースを更新

## Changes
- `src/components/auth/login-form.tsx`: callbackUrlのデフォルト値を `/` から `/dashboard` に変更
- `src/components/auth/login-form.test.tsx`: 期待値を `/dashboard` に更新

## Test plan
- [x] `npm test -- src/components/auth/login-form.test.tsx` が通ること
- [x] `npm run lint` でエラーがないこと
- [x] `npm run type-check` でエラーがないこと

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)