### PR TITLE
feat: Issue #55 サイドメニューに日報作成メニュー項目を追加

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileText, Users, Building2, Home } from "lucide-react";
+import { FileText, Users, Building2, Home, PlusCircle } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -24,6 +24,12 @@ interface NavItem {
 const navItems: NavItem[] = [
   { id: "dashboard", label: "ダッシュボード", href: "/dashboard", icon: Home },
   { id: "reports", label: "日報一覧", href: "/reports", icon: FileText },
+  {
+    id: "reports-new",
+    label: "日報作成",
+    href: "/reports/new",
+    icon: PlusCircle,
+  },
   { id: "customers", label: "顧客マスタ", href: "/customers", icon: Building2 },
   {
     id: "sales-persons",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -16,6 +16,7 @@ export function canAccessMenu(menuId: string, role: UserRole): boolean {
   const menuPermissions: Record<string, UserRole[]> = {
     dashboard: ["member", "manager", "admin"],
     reports: ["member", "manager", "admin"],
+    "reports-new": ["member", "manager", "admin"],
     customers: ["member", "manager", "admin"],
     "sales-persons": ["admin"],
   };


### PR DESCRIPTION
## Summary
- サイドメニュー（ドロワー）に「日報作成」メニュー項目を追加
- 全ロール（member/manager/admin）で日報作成メニューが表示される

## Changes
- `src/components/layout/Sidebar.tsx`:
  - navItemsに `reports-new` を追加（日報一覧と顧客マスタの間）
  - `PlusCircle`アイコンをインポート
- `src/types/auth.ts`:
  - canAccessMenu関数の`menuPermissions`に `"reports-new"` を追加

## Test plan
- [x] `npm test` 全1303テストがパス
- [x] `npm run lint` でエラーがないこと
- [x] `npm run type-check` でエラーがないこと
- [ ] 手動テスト: サイドメニューに「日報作成」が表示されること
- [ ] 手動テスト: 「日報作成」クリックで `/reports/new` に遷移すること

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)