### PR TITLE
feat: Issue #56 全デバイスでハンバーガーメニューを表示するようヘッダーを修正

### DIFF
--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -1,18 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 
-import {
-  render,
-  screen,
-  mockMemberUser,
-  mockManagerUser,
-  mockAdminUser,
-} from "@/test/test-utils";
+import { render, screen, mockMemberUser } from "@/test/test-utils";
 
 import { Header } from "./Header";
 
 // next/navigation のモック
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/dashboard",
   useRouter: () => ({
     push: vi.fn(),
     replace: vi.fn(),
@@ -31,12 +24,13 @@ describe("Header", () => {
       expect(screen.getByText("営業日報システム")).toBeInTheDocument();
     });
 
-    it("should render mobile menu button", () => {
+    it("should render hamburger menu button on all devices", () => {
       render(<Header />, { user: mockMemberUser });
 
-      expect(
-        screen.getByRole("button", { name: "メニューを開く" })
-      ).toBeInTheDocument();
+      const menuButton = screen.getByRole("button", { name: "メニューを開く" });
+      expect(menuButton).toBeInTheDocument();
+      // md:hidden クラスが削除されていることを確認（全デバイスで表示）
+      expect(menuButton).not.toHaveClass("md:hidden");
     });
 
     it("should render user avatar button", () => {
@@ -45,36 +39,6 @@ describe("Header", () => {
       expect(
         screen.getByRole("button", { name: "ユーザーメニュー" })
       ).toBeInTheDocument();
-    });
-  });
-
-  describe("navigation items for member", () => {
-    it("should show reports and customers menu but not sales-persons", () => {
-      render(<Header />, { user: mockMemberUser });
-
-      expect(screen.getByText("日報一覧")).toBeInTheDocument();
-      expect(screen.getByText("顧客マスタ")).toBeInTheDocument();
-      expect(screen.queryByText("営業マスタ")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("navigation items for manager", () => {
-    it("should show reports and customers menu but not sales-persons", () => {
-      render(<Header />, { user: mockManagerUser });
-
-      expect(screen.getByText("日報一覧")).toBeInTheDocument();
-      expect(screen.getByText("顧客マスタ")).toBeInTheDocument();
-      expect(screen.queryByText("営業マスタ")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("navigation items for admin", () => {
-    it("should show all menu items including sales-persons", () => {
-      render(<Header />, { user: mockAdminUser });
-
-      expect(screen.getByText("日報一覧")).toBeInTheDocument();
-      expect(screen.getByText("顧客マスタ")).toBeInTheDocument();
-      expect(screen.getByText("営業マスタ")).toBeInTheDocument();
     });
   });
 
@@ -107,7 +71,7 @@ describe("Header", () => {
   });
 
   describe("menu click callback", () => {
-    it("should call onMenuClick when mobile menu button is clicked", async () => {
+    it("should call onMenuClick when hamburger menu button is clicked", async () => {
       const onMenuClick = vi.fn();
       const { user } = render(<Header onMenuClick={onMenuClick} />, {
         user: mockMemberUser,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,16 +1,8 @@
 "use client";
 
-import {
-  FileText,
-  Users,
-  Building2,
-  User,
-  KeyRound,
-  LogOut,
-  Menu,
-} from "lucide-react";
+import { FileText, User, KeyRound, LogOut, Menu } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -22,26 +14,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/contexts/AuthContext";
-import { cn } from "@/lib/utils";
-import { canAccessMenu } from "@/types/auth";
-
-interface NavItem {
-  id: string;
-  label: string;
-  href: string;
-  icon: React.ComponentType<{ className?: string }>;
-}
-
-const navItems: NavItem[] = [
-  { id: "reports", label: "日報一覧", href: "/reports", icon: FileText },
-  { id: "customers", label: "顧客マスタ", href: "/customers", icon: Building2 },
-  {
-    id: "sales-persons",
-    label: "営業マスタ",
-    href: "/sales-persons",
-    icon: Users,
-  },
-];
 
 interface HeaderProps {
   onMenuClick?: () => void;
@@ -49,7 +21,6 @@ interface HeaderProps {
 
 export function Header({ onMenuClick }: HeaderProps) {
   const { user, logout } = useAuth();
-  const pathname = usePathname();
   const router = useRouter();
 
   const handleLogout = async () => {
@@ -66,18 +37,14 @@ export function Header({ onMenuClick }: HeaderProps) {
       .toUpperCase();
   };
 
-  const visibleNavItems = navItems.filter(
-    (item) => user && canAccessMenu(item.id, user.role)
-  );
-
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
-        {/* モバイルメニューボタン */}
+        {/* ハンバーガーメニューボタン */}
         <Button
           variant="ghost"
           size="icon"
-          className="mr-2 md:hidden"
+          className="mr-2"
           onClick={onMenuClick}
           aria-label="メニューを開く"
         >
@@ -87,34 +54,11 @@ export function Header({ onMenuClick }: HeaderProps) {
         {/* ロゴ */}
         <Link
           href="/dashboard"
-          className="mr-6 flex items-center space-x-2 font-bold"
+          className="flex items-center space-x-2 font-bold"
         >
           <FileText className="h-5 w-5" />
           <span className="hidden sm:inline-block">営業日報システム</span>
         </Link>
-
-        {/* デスクトップナビゲーション */}
-        <nav className="hidden md:flex md:flex-1 md:items-center md:space-x-1">
-          {visibleNavItems.map((item) => {
-            const Icon = item.icon;
-            const isActive = pathname.startsWith(item.href);
-            return (
-              <Link
-                key={item.id}
-                href={item.href}
-                className={cn(
-                  "flex items-center space-x-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-accent text-accent-foreground"
-                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                )}
-              >
-                <Icon className="h-4 w-4" />
-                <span>{item.label}</span>
-              </Link>
-            );
-          })}
-        </nav>
 
         {/* ユーザーメニュー */}
         <div className="ml-auto flex items-center">


### PR DESCRIPTION
## Summary
- 全デバイス（デスクトップ含む）でハンバーガーボタン（≡）を表示
- デスクトップのインラインナビゲーションを削除
- ナビゲーションはサイドメニュー（ドロワー）に統一

## Changes
### `src/components/layout/Header.tsx`
- ハンバーガーボタンの `md:hidden` クラスを削除
- デスクトップナビゲーション（`<nav>`）を削除
- 不要になったインポートを削除（Users, Building2, usePathname, cn, canAccessMenu）
- navItems定義を削除

### `src/components/layout/Header.test.tsx`
- デスクトップナビゲーションのテストを削除（member/manager/adminのメニュー表示テスト）
- ハンバーガーボタンが全デバイスで表示されることを確認するテストを追加

## Before/After
### Before (モバイルのみハンバーガー、デスクトップはインラインナビ)
```
モバイル: [≡] [ロゴ]                      [ユーザー]
デスクトップ: [ロゴ] [日報一覧] [顧客] [営業] [ユーザー]
```

### After (全デバイスでハンバーガー)
```
全デバイス: [≡] [ロゴ] 営業日報システム    [ユーザー]
```

## Test plan
- [x] `npm test` 全1300テストがパス
- [x] `npm run lint` でエラーがないこと
- [x] `npm run type-check` でエラーがないこと
- [ ] 手動テスト: デスクトップでハンバーガーボタンが表示されること
- [ ] 手動テスト: ハンバーガーボタンクリックでサイドメニューが開くこと

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)