### PR TITLE
test: ナビゲーション機能のユニットテストを追加 (#57)

### DIFF
--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -24,6 +24,13 @@ describe("Header", () => {
       expect(screen.getByText("営業日報システム")).toBeInTheDocument();
     });
 
+    it("should have logo link to dashboard (UT-NAV-009)", () => {
+      render(<Header />, { user: mockMemberUser });
+
+      const logoLink = screen.getByText("営業日報システム").closest("a");
+      expect(logoLink).toHaveAttribute("href", "/dashboard");
+    });
+
     it("should render hamburger menu button on all devices", () => {
       render(<Header />, { user: mockMemberUser });
 

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -36,7 +36,18 @@ describe("Sidebar", () => {
 
       expect(screen.getByText("ダッシュボード")).toBeInTheDocument();
       expect(screen.getByText("日報一覧")).toBeInTheDocument();
+      expect(screen.getByText("日報作成")).toBeInTheDocument();
       expect(screen.getByText("顧客マスタ")).toBeInTheDocument();
+    });
+
+    it("should have correct link for reports-new menu (UT-NAV-004)", () => {
+      const onOpenChange = vi.fn();
+      render(<Sidebar open={true} onOpenChange={onOpenChange} />, {
+        user: mockMemberUser,
+      });
+
+      const reportsNewLink = screen.getByText("日報作成").closest("a");
+      expect(reportsNewLink).toHaveAttribute("href", "/reports/new");
     });
 
     it("should not show sales-persons menu for member", () => {
@@ -68,6 +79,7 @@ describe("Sidebar", () => {
 
       expect(screen.getByText("ダッシュボード")).toBeInTheDocument();
       expect(screen.getByText("日報一覧")).toBeInTheDocument();
+      expect(screen.getByText("日報作成")).toBeInTheDocument();
       expect(screen.getByText("顧客マスタ")).toBeInTheDocument();
       expect(screen.getByText("営業マスタ")).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- Sidebar.test.tsx: 日報作成メニューの表示とリンク検証テスト追加
- Header.test.tsx: ロゴクリックでダッシュボード遷移のテスト追加

## テストケースID
- UT-NAV-004: サイドメニューから日報作成へ遷移できること
- UT-NAV-009: ヘッダーのロゴをクリックでダッシュボードへ遷移すること

## Test plan
- [x] `npm test -- --run src/components/layout/Sidebar.test.tsx src/components/layout/Header.test.tsx` でテスト成功
- [x] `npm run lint` でエラーなし
- [x] `npm run type-check` でエラーなし

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)