### PR TITLE
fix: ログアウトボタンが機能しない問題を修正 (#65)

### DIFF
--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, mockMemberUser } from "@/test/test-utils";
 
 import { Header } from "./Header";
 
-// next/navigation のモック
+// next/navigation のモック（Linkコンポーネント用に残す）
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: vi.fn(),
@@ -14,6 +14,11 @@ vi.mock("next/navigation", () => ({
     forward: vi.fn(),
     prefetch: vi.fn(),
   }),
+}));
+
+// auth-actions のモック
+vi.mock("@/lib/auth-actions", () => ({
+  logout: vi.fn(),
 }));
 
 describe("Header", () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,6 @@
 
 import { FileText, User, KeyRound, LogOut, Menu } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -14,18 +13,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/contexts/AuthContext";
+import { logout } from "@/lib/auth-actions";
 
 interface HeaderProps {
   onMenuClick?: () => void;
 }
 
 export function Header({ onMenuClick }: HeaderProps) {
-  const { user, logout } = useAuth();
-  const router = useRouter();
+  const { user } = useAuth();
 
   const handleLogout = async () => {
     await logout();
-    router.push("/login");
   };
 
   const getInitials = (name: string) => {


### PR DESCRIPTION
## Summary
- ログアウトボタンを押下してもログアウトされない問題を修正
- Header.tsxでAuthContextのlogout()ではなく、auth-actionsのlogout（Server Action）を直接使用するように変更

## 原因
`Header.tsx`の`handleLogout`は`useAuth()`から取得した`logout`関数を呼んでいたが、`AuthContext`の`logout`は`setUser(null)`を実行するだけで、NextAuthの`signOut()`を呼んでいなかった。

## 修正内容
- `Header.tsx`: `auth-actions`の`logout`（Server Action）を直接インポートして使用
- `Header.tsx`: `useRouter`を削除（`signOut`がリダイレクトを処理するため不要）
- `Header.test.tsx`: `auth-actions`のモックを追加

## Test plan
- [x] `npm run lint` でエラーなし
- [x] `npm run type-check` でエラーなし
- [x] `npm test -- --run` で全1302テストパス
- [x] ローカルでログインし、ログアウトボタンを押下してログアウトされることを確認
- [x] ログアウト後、ログイン画面に遷移することを確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)